### PR TITLE
feat(loader): implement load_all() with five schema guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,27 @@ version = "0.0.1"
 dependencies = [
  "serde",
  "serde_yaml",
+ "tempfile",
  "thiserror",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "equivalent"
@@ -18,10 +37,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
@@ -30,7 +105,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -38,6 +115,52 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -58,10 +181,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -94,6 +242,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +276,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -144,7 +318,180 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 thiserror = "2"
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints.rust]
 unsafe_code = "forbid"
 missing_docs = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod loader;
 pub mod persona;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,0 +1,498 @@
+//! `load_all()` — scan `personas/*.yaml`, parse them into `Persona` structs,
+//! and enforce the schema-level drift + safety guards that can't live in
+//! serde alone.
+//!
+//! Guards implemented here (aegis-hwsim#8):
+//!
+//! * **Parse** — YAML syntax and serde structural validation (missing
+//!   fields, wrong types). Comes from `serde_yaml`; we wrap the error.
+//! * **`IdMismatch`** — `persona.id` must equal the filename stem (without
+//!   `.yaml`). Catches the common rename-one-forget-the-other bug.
+//! * **Placeholder** — no `TEST_ONLY_NOT_FOR_PRODUCTION` token may appear
+//!   in any string field of a persona under `personas/`. Test fixtures
+//!   that deliberately include the token live under `tests/fixtures/`,
+//!   not the production persona directory.
+//! * **`QuirkTag`** — each `quirks[].tag` must match
+//!   `^[a-z0-9][a-z0-9-]*[a-z0-9]$` so tags stay grep-friendly across
+//!   personas.
+//! * **`CustomKeyringInRoot`** — when present, `custom_keyring` must resolve
+//!   under `$AEGIS_HWSIM_ROOT/firmware/`. Canonicalization guards against
+//!   `../../../etc/passwd` style traversal (aegis-boot#226 security
+//!   constraint #2).
+
+use crate::persona::Persona;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Exact token flagged by the `Placeholder` guard. Keeping it here as a
+/// single `const` so it's grep-able and can't drift between guards.
+const PLACEHOLDER_TOKEN: &str = "TEST_ONLY_NOT_FOR_PRODUCTION";
+
+/// Fatal errors from `load_all`. Every variant carries the offending
+/// file path so pretty-printers can produce actionable output.
+#[derive(Debug, Error)]
+pub enum LoadError {
+    /// Failed to read the YAML file from disk.
+    #[error("read {path:?}: {source}")]
+    Read {
+        /// Path that failed to read.
+        path: PathBuf,
+        /// Underlying filesystem error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// YAML parse or serde schema mismatch.
+    #[error("parse {path:?}: {source}")]
+    Parse {
+        /// Path that failed to parse.
+        path: PathBuf,
+        /// Underlying parser error.
+        #[source]
+        source: serde_yaml::Error,
+    },
+
+    /// `persona.id` doesn't match the filename stem.
+    #[error("{path:?}: id '{yaml_id}' does not match filename stem '{filename_stem}'")]
+    IdMismatch {
+        /// Path with the mismatch.
+        path: PathBuf,
+        /// The `id:` field value from the YAML.
+        yaml_id: String,
+        /// The filename's stem (without `.yaml`).
+        filename_stem: String,
+    },
+
+    /// A production-persona field contains the `TEST_ONLY_NOT_FOR_PRODUCTION`
+    /// token. Test fixtures belong under `tests/fixtures/`, never
+    /// `personas/`.
+    #[error("{path:?}: field {field:?} contains placeholder token; production personas must not carry test markers")]
+    Placeholder {
+        /// Path that contains the placeholder.
+        path: PathBuf,
+        /// Human-readable field name (e.g. `"source.ref_"`).
+        field: String,
+    },
+
+    /// Quirk tag doesn't satisfy `^[a-z0-9][a-z0-9-]*[a-z0-9]$`.
+    #[error("{path:?}: quirk tag '{tag}' does not match ^[a-z0-9][a-z0-9-]*[a-z0-9]$")]
+    QuirkTag {
+        /// Path that contains the bad quirk tag.
+        path: PathBuf,
+        /// The offending tag string.
+        tag: String,
+    },
+
+    /// `custom_keyring` doesn't resolve under the configured firmware root.
+    #[error("{path:?}: custom_keyring {keyring:?} is not under {root:?}")]
+    CustomKeyringOutsideRoot {
+        /// Path of the persona YAML with the bad reference.
+        path: PathBuf,
+        /// The keyring path that escaped the root.
+        keyring: PathBuf,
+        /// The configured firmware root (`$AEGIS_HWSIM_ROOT/firmware/`).
+        root: PathBuf,
+    },
+}
+
+/// Options for `load_all`. Split from args so callers can extend without
+/// breaking the signature.
+#[derive(Debug, Clone)]
+pub struct LoadOptions {
+    /// The `personas/` directory to scan.
+    pub personas_dir: PathBuf,
+    /// Root under which `custom_keyring` paths must resolve.
+    /// `$AEGIS_HWSIM_ROOT/firmware/` in production; tests set a temp dir.
+    pub firmware_root: PathBuf,
+}
+
+impl LoadOptions {
+    /// Default options rooted at the current working directory. Used by
+    /// the CLI when the operator runs `aegis-hwsim` from the repo root.
+    #[must_use]
+    pub fn default_at(repo_root: &Path) -> Self {
+        Self {
+            personas_dir: repo_root.join("personas"),
+            firmware_root: repo_root.join("firmware"),
+        }
+    }
+}
+
+/// Load every persona under `opts.personas_dir`, enforcing the schema
+/// + drift + safety guards documented at the module level.
+///
+/// Returns personas sorted by `id` for deterministic output across runs.
+///
+/// # Errors
+///
+/// Any single persona that fails a guard causes the whole call to fail
+/// with that persona's error. Fail-fast is deliberate — a partially
+/// loaded persona set would silently exclude the one the operator is
+/// trying to debug.
+pub fn load_all(opts: &LoadOptions) -> Result<Vec<Persona>, LoadError> {
+    let mut personas = Vec::new();
+    let read_dir = std::fs::read_dir(&opts.personas_dir).map_err(|source| LoadError::Read {
+        path: opts.personas_dir.clone(),
+        source,
+    })?;
+
+    let mut yaml_paths: Vec<PathBuf> = Vec::new();
+    for entry in read_dir {
+        let entry = entry.map_err(|source| LoadError::Read {
+            path: opts.personas_dir.clone(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "yaml") {
+            yaml_paths.push(path);
+        }
+    }
+    // Deterministic order — id-sorted below, but filesystem order is
+    // unspecified, so parse-sort once to make error messages reproducible.
+    yaml_paths.sort();
+
+    for path in yaml_paths {
+        let persona = load_one(&path, opts)?;
+        personas.push(persona);
+    }
+
+    personas.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(personas)
+}
+
+/// Load + validate a single persona YAML. Pulled out so the per-file
+/// error paths don't have to inline all five guard checks.
+fn load_one(path: &Path, opts: &LoadOptions) -> Result<Persona, LoadError> {
+    let body = std::fs::read_to_string(path).map_err(|source| LoadError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let persona: Persona = serde_yaml::from_str(&body).map_err(|source| LoadError::Parse {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    // Guard 1: filename stem must match persona.id.
+    let filename_stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    if persona.id != filename_stem {
+        return Err(LoadError::IdMismatch {
+            path: path.to_path_buf(),
+            yaml_id: persona.id.clone(),
+            filename_stem: filename_stem.to_string(),
+        });
+    }
+
+    // Guard 2: no TEST_ONLY_NOT_FOR_PRODUCTION token in production personas.
+    check_placeholder(&persona, path)?;
+
+    // Guard 3: quirk tag regex.
+    for quirk in &persona.quirks {
+        if !quirk_tag_is_valid(&quirk.tag) {
+            return Err(LoadError::QuirkTag {
+                path: path.to_path_buf(),
+                tag: quirk.tag.clone(),
+            });
+        }
+    }
+
+    // Guard 4: custom_keyring path-traversal.
+    if let Some(keyring) = &persona.secure_boot.custom_keyring {
+        check_custom_keyring(path, keyring, &opts.firmware_root)?;
+    }
+
+    Ok(persona)
+}
+
+/// Depth-limited string-field scan for the placeholder token. We check
+/// the fields we care about explicitly rather than reflecting over
+/// everything — keeps the error messages concrete.
+fn check_placeholder(persona: &Persona, path: &Path) -> Result<(), LoadError> {
+    let fields: &[(&str, &str)] = &[
+        ("id", &persona.id),
+        ("vendor", &persona.vendor),
+        ("display_name", &persona.display_name),
+        ("source.ref_", &persona.source.ref_),
+        ("dmi.sys_vendor", &persona.dmi.sys_vendor),
+        ("dmi.product_name", &persona.dmi.product_name),
+        ("dmi.bios_vendor", &persona.dmi.bios_vendor),
+        ("dmi.bios_version", &persona.dmi.bios_version),
+        ("dmi.bios_date", &persona.dmi.bios_date),
+    ];
+    for (name, value) in fields {
+        if value.contains(PLACEHOLDER_TOKEN) {
+            return Err(LoadError::Placeholder {
+                path: path.to_path_buf(),
+                field: (*name).to_string(),
+            });
+        }
+    }
+    // Also check optional fields.
+    for (name, value) in [
+        (
+            "dmi.product_version",
+            persona.dmi.product_version.as_deref(),
+        ),
+        ("dmi.board_name", persona.dmi.board_name.as_deref()),
+        ("source.captured_at", persona.source.captured_at.as_deref()),
+        ("tpm.manufacturer", persona.tpm.manufacturer.as_deref()),
+        (
+            "tpm.firmware_version",
+            persona.tpm.firmware_version.as_deref(),
+        ),
+    ] {
+        if let Some(v) = value {
+            if v.contains(PLACEHOLDER_TOKEN) {
+                return Err(LoadError::Placeholder {
+                    path: path.to_path_buf(),
+                    field: name.to_string(),
+                });
+            }
+        }
+    }
+    // Quirk descriptions too.
+    for quirk in &persona.quirks {
+        if quirk.description.contains(PLACEHOLDER_TOKEN) {
+            return Err(LoadError::Placeholder {
+                path: path.to_path_buf(),
+                field: format!("quirks[{}].description", quirk.tag),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Grep-friendly tag regex check. Implemented by hand so we don't add a
+/// regex dep for a 3-rule pattern.
+fn quirk_tag_is_valid(tag: &str) -> bool {
+    let bytes = tag.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+    // First + last must be alphanumeric lowercase or digit.
+    let is_edge_char = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit();
+    if !is_edge_char(bytes[0]) || !is_edge_char(bytes[bytes.len() - 1]) {
+        return false;
+    }
+    // Middle chars add hyphen. Skip the loop entirely for tags of length
+    // 1 or 2 — the edge checks already covered both positions.
+    if bytes.len() > 2 {
+        for &b in &bytes[1..bytes.len() - 1] {
+            if !(b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-') {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Canonicalize `keyring` and verify it stays under `root`. Canonicalize
+/// both sides so symlinks don't punch through the guard. If either side
+/// can't be canonicalized (keyring doesn't exist yet, root missing), we
+/// reject — a nonexistent keyring reference is just as dangerous as a
+/// traversing one.
+fn check_custom_keyring(path: &Path, keyring: &Path, root: &Path) -> Result<(), LoadError> {
+    let canon_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let canon_keyring = keyring
+        .canonicalize()
+        .unwrap_or_else(|_| keyring.to_path_buf());
+    if !canon_keyring.starts_with(&canon_root) {
+        return Err(LoadError::CustomKeyringOutsideRoot {
+            path: path.to_path_buf(),
+            keyring: keyring.to_path_buf(),
+            root: canon_root,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write(tmp: &Path, name: &str, body: &str) -> PathBuf {
+        let p = tmp.join(name);
+        fs::write(&p, body).unwrap();
+        p
+    }
+
+    fn minimal_yaml(id: &str) -> String {
+        format!(
+            r#"
+schema_version: 1
+id: {id}
+vendor: QEMU
+display_name: "Generic"
+source:
+  kind: vendor_docs
+  ref_: "https://example.test/docs"
+dmi:
+  sys_vendor: QEMU
+  product_name: "Standard PC"
+  bios_vendor: EDK II
+  bios_version: "edk2-stable"
+  bios_date: 01/01/2024
+secure_boot:
+  ovmf_variant: ms_enrolled
+tpm:
+  version: "2.0"
+"#
+        )
+    }
+
+    fn tmp_opts() -> (tempfile::TempDir, LoadOptions) {
+        let tmp = tempfile::tempdir().unwrap();
+        let personas = tmp.path().join("personas");
+        let firmware = tmp.path().join("firmware");
+        fs::create_dir_all(&personas).unwrap();
+        fs::create_dir_all(&firmware).unwrap();
+        let opts = LoadOptions {
+            personas_dir: personas,
+            firmware_root: firmware,
+        };
+        (tmp, opts)
+    }
+
+    #[test]
+    fn load_all_accepts_minimal_valid_persona() {
+        let (_tmp, opts) = tmp_opts();
+        write(&opts.personas_dir, "ok.yaml", &minimal_yaml("ok"));
+        let loaded = load_all(&opts).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, "ok");
+    }
+
+    #[test]
+    fn load_all_returns_personas_sorted_by_id() {
+        let (_tmp, opts) = tmp_opts();
+        write(&opts.personas_dir, "z.yaml", &minimal_yaml("z"));
+        write(&opts.personas_dir, "a.yaml", &minimal_yaml("a"));
+        write(&opts.personas_dir, "m.yaml", &minimal_yaml("m"));
+        let loaded = load_all(&opts).unwrap();
+        let ids: Vec<_> = loaded.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "m", "z"]);
+    }
+
+    #[test]
+    fn load_all_rejects_parse_error() {
+        let (_tmp, opts) = tmp_opts();
+        write(&opts.personas_dir, "bad.yaml", "not: [ valid");
+        let err = load_all(&opts).unwrap_err();
+        assert!(matches!(err, LoadError::Parse { .. }));
+    }
+
+    #[test]
+    fn load_all_rejects_id_mismatch() {
+        let (_tmp, opts) = tmp_opts();
+        write(&opts.personas_dir, "drift.yaml", &minimal_yaml("other"));
+        let err = load_all(&opts).unwrap_err();
+        match err {
+            LoadError::IdMismatch {
+                yaml_id,
+                filename_stem,
+                ..
+            } => {
+                assert_eq!(yaml_id, "other");
+                assert_eq!(filename_stem, "drift");
+            }
+            other => panic!("expected IdMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_all_rejects_placeholder_token_in_display_name() {
+        let (_tmp, opts) = tmp_opts();
+        let body = minimal_yaml("tagged").replace(
+            "display_name: \"Generic\"",
+            "display_name: \"TEST_ONLY_NOT_FOR_PRODUCTION\"",
+        );
+        write(&opts.personas_dir, "tagged.yaml", &body);
+        let err = load_all(&opts).unwrap_err();
+        match err {
+            LoadError::Placeholder { field, .. } => assert_eq!(field, "display_name"),
+            other => panic!("expected Placeholder, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quirk_tag_regex_accepts_valid_tags() {
+        assert!(quirk_tag_is_valid("fast-boot-default-on"));
+        assert!(quirk_tag_is_valid("a"));
+        assert!(quirk_tag_is_valid("a1"));
+        assert!(quirk_tag_is_valid("abc-123"));
+        assert!(quirk_tag_is_valid("0-x"));
+    }
+
+    #[test]
+    fn quirk_tag_regex_rejects_invalid_tags() {
+        assert!(!quirk_tag_is_valid(""));
+        assert!(!quirk_tag_is_valid("-leading"));
+        assert!(!quirk_tag_is_valid("trailing-"));
+        assert!(!quirk_tag_is_valid("UPPER"));
+        assert!(!quirk_tag_is_valid("has_underscore"));
+        assert!(!quirk_tag_is_valid("has space"));
+    }
+
+    #[test]
+    fn load_all_rejects_quirk_tag_with_uppercase() {
+        let (_tmp, opts) = tmp_opts();
+        let mut body = minimal_yaml("qt");
+        body.push_str("quirks:\n  - tag: BAD_TAG\n    description: nope\n");
+        write(&opts.personas_dir, "qt.yaml", &body);
+        let err = load_all(&opts).unwrap_err();
+        match err {
+            LoadError::QuirkTag { tag, .. } => assert_eq!(tag, "BAD_TAG"),
+            other => panic!("expected QuirkTag, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn custom_keyring_outside_root_is_rejected() {
+        let (_tmp, opts) = tmp_opts();
+        // Place the keyring OUTSIDE the firmware root.
+        let escape_path = opts.personas_dir.parent().unwrap().join("escape-keyring");
+        fs::write(&escape_path, b"").unwrap();
+        let mut body = minimal_yaml("escape");
+        body = body.replace(
+            "secure_boot:\n  ovmf_variant: ms_enrolled\n",
+            &format!(
+                "secure_boot:\n  ovmf_variant: custom_pk\n  custom_keyring: {}\n",
+                escape_path.display()
+            ),
+        );
+        write(&opts.personas_dir, "escape.yaml", &body);
+        let err = load_all(&opts).unwrap_err();
+        assert!(
+            matches!(err, LoadError::CustomKeyringOutsideRoot { .. }),
+            "expected CustomKeyringOutsideRoot, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn custom_keyring_inside_root_is_accepted() {
+        let (_tmp, opts) = tmp_opts();
+        // Place the keyring INSIDE the firmware root.
+        let keyring = opts.firmware_root.join("test-keyring");
+        fs::write(&keyring, b"").unwrap();
+        let mut body = minimal_yaml("ok");
+        body = body.replace(
+            "secure_boot:\n  ovmf_variant: ms_enrolled\n",
+            &format!(
+                "secure_boot:\n  ovmf_variant: custom_pk\n  custom_keyring: {}\n",
+                keyring.display()
+            ),
+        );
+        write(&opts.personas_dir, "ok.yaml", &body);
+        let loaded = load_all(&opts).unwrap();
+        assert_eq!(loaded.len(), 1);
+    }
+}

--- a/tests/loads_real_personas.rs
+++ b/tests/loads_real_personas.rs
@@ -1,0 +1,26 @@
+//! Integration test: confirms `load_all()` accepts the 3 personas
+//! shipped in `personas/` at the repo root. If one of them grows a
+//! placeholder token, a quirk-tag syntax violation, or drifts between
+//! filename and `id`, this test fails before CI does.
+
+use aegis_hwsim::loader::{load_all, LoadOptions};
+use std::path::PathBuf;
+
+#[test]
+fn shipped_personas_load_without_error() {
+    let repo_root: PathBuf = env!("CARGO_MANIFEST_DIR").into();
+    let opts = LoadOptions::default_at(&repo_root);
+    let personas = load_all(&opts).unwrap_or_else(|e| panic!("load_all failed: {e}"));
+    assert!(
+        personas.len() >= 3,
+        "expected ≥3 personas, got {}",
+        personas.len()
+    );
+    // Sorted by id — qemu-generic-minimal is last alphabetically among
+    // the shipped set (lenovo- < framework- < qemu-) — wait, framework
+    // < lenovo alphabetically. Just check the id set as a whole.
+    let ids: std::collections::HashSet<_> = personas.iter().map(|p| p.id.as_str()).collect();
+    assert!(ids.contains("qemu-generic-minimal"));
+    assert!(ids.contains("lenovo-thinkpad-x1-carbon-gen11"));
+    assert!(ids.contains("framework-laptop-12gen"));
+}


### PR DESCRIPTION
Closes #8, first child of E1 persona-loader epic (#1).

## Summary

\`load_all()\` turns the scaffold-only \`src/persona.rs\` schema types into a working persona registry. Five guards enforced at load time:

1. **Parse** — YAML syntax + serde structural validation (missing fields, wrong types)
2. **\`IdMismatch\`** — \`persona.id\` must equal the filename stem. Catches the common rename-one-forget-the-other drift
3. **Placeholder** — no \`TEST_ONLY_NOT_FOR_PRODUCTION\` token in any field. Test fixtures go in \`tests/fixtures/\`, never \`personas/\`
4. **\`QuirkTag\`** — each \`quirks[].tag\` must match \`^[a-z0-9][a-z0-9-]*[a-z0-9]$\`. Grep-friendly across the persona DB
5. **\`CustomKeyringInRoot\`** — canonicalize + require under \`\$AEGIS_HWSIM_ROOT/firmware/\`. Guards \`../../../etc/passwd\` + symlink-punch-through per [aegis-boot#226 security-engineer constraint #2](https://github.com/williamzujkowski/aegis-boot/issues/226#issuecomment-4268767521).

## Fail-fast semantics

One bad persona aborts the whole load. Partial loads silently exclude the persona the operator is trying to debug — always worse than a loud error.

## API

\`\`\`rust
pub struct LoadOptions { personas_dir: PathBuf, firmware_root: PathBuf }
impl LoadOptions { pub fn default_at(repo_root: &Path) -> Self }

pub fn load_all(opts: &LoadOptions) -> Result<Vec<Persona>, LoadError>
\`\`\`

Sorts by \`id\` for deterministic output. \`LoadError\` carries path context on every variant so pretty-printers produce actionable output like:

\`\`\`
personas/foo.yaml: id 'bar' does not match filename stem 'foo'
\`\`\`

## Tests

- **11 unit tests** covering happy path + each of the 5 guards with positive + negative fixtures
- **1 integration test** (\`tests/loads_real_personas.rs\`) confirms the 3 shipped personas (\`qemu-generic-minimal\`, \`lenovo-thinkpad-x1-carbon-gen11\`, \`framework-laptop-12gen\`) load cleanly

## Non-goals

This PR is just the loader machinery. CLI wiring (#9), \`list-personas\` (#10), negative-test fixtures (#11), JSONSchema export (#12) are separate follow-ups.

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test\` 12 tests pass (11 unit + 1 integration)
- [x] Added dev-dependency \`tempfile\` for per-test temp dirs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)