### PR TITLE
test(loader): negative-fixture integration tests (E1.4, closes #11)

### DIFF
--- a/tests/fixtures/bad-custom-keyring-traversal.yaml
+++ b/tests/fixtures/bad-custom-keyring-traversal.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+id: bad-custom-keyring-traversal
+vendor: QEMU
+display_name: "custom_keyring escapes firmware root"
+source:
+  kind: vendor_docs
+  ref_: "negative test fixture"
+dmi:
+  sys_vendor: QEMU
+  product_name: "Standard PC"
+  bios_vendor: EDK II
+  bios_version: "edk2-stable"
+  bios_date: 01/01/2024
+secure_boot:
+  ovmf_variant: custom_pk
+  # Absolute path well outside any reasonable firmware root — the
+  # CustomKeyringOutsideRoot guard fires.
+  custom_keyring: /etc/passwd
+tpm:
+  version: "2.0"

--- a/tests/fixtures/bad-id-filename-drift.yaml
+++ b/tests/fixtures/bad-id-filename-drift.yaml
@@ -1,0 +1,18 @@
+schema_version: 1
+# id deliberately does NOT match the filename stem — IdMismatch guard fires.
+id: wrong-id-here
+vendor: QEMU
+display_name: "Deliberately drifted id"
+source:
+  kind: vendor_docs
+  ref_: "negative test fixture"
+dmi:
+  sys_vendor: QEMU
+  product_name: "Standard PC"
+  bios_vendor: EDK II
+  bios_version: "edk2-stable"
+  bios_date: 01/01/2024
+secure_boot:
+  ovmf_variant: ms_enrolled
+tpm:
+  version: "2.0"

--- a/tests/fixtures/bad-missing-schema-version.yaml
+++ b/tests/fixtures/bad-missing-schema-version.yaml
@@ -1,0 +1,17 @@
+# Missing schema_version — serde should flag the required field.
+id: bad-missing-schema-version
+vendor: QEMU
+display_name: "Deliberately broken — no schema_version"
+source:
+  kind: vendor_docs
+  ref_: "negative test fixture"
+dmi:
+  sys_vendor: QEMU
+  product_name: "Standard PC"
+  bios_vendor: EDK II
+  bios_version: "edk2-stable"
+  bios_date: 01/01/2024
+secure_boot:
+  ovmf_variant: ms_enrolled
+tpm:
+  version: "2.0"

--- a/tests/fixtures/bad-placeholder-token.yaml
+++ b/tests/fixtures/bad-placeholder-token.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+id: bad-placeholder-token
+vendor: QEMU
+# This display_name contains the placeholder marker that production
+# personas MUST NOT carry — the loader's Placeholder guard fires.
+display_name: "TEST_ONLY_NOT_FOR_PRODUCTION test fixture"
+source:
+  kind: vendor_docs
+  ref_: "negative test fixture"
+dmi:
+  sys_vendor: QEMU
+  product_name: "Standard PC"
+  bios_vendor: EDK II
+  bios_version: "edk2-stable"
+  bios_date: 01/01/2024
+secure_boot:
+  ovmf_variant: ms_enrolled
+tpm:
+  version: "2.0"

--- a/tests/fixtures/bad-quirk-tag-syntax.yaml
+++ b/tests/fixtures/bad-quirk-tag-syntax.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+id: bad-quirk-tag-syntax
+vendor: QEMU
+display_name: "Quirk tag fails the regex"
+source:
+  kind: vendor_docs
+  ref_: "negative test fixture"
+dmi:
+  sys_vendor: QEMU
+  product_name: "Standard PC"
+  bios_vendor: EDK II
+  bios_version: "edk2-stable"
+  bios_date: 01/01/2024
+secure_boot:
+  ovmf_variant: ms_enrolled
+tpm:
+  version: "2.0"
+quirks:
+  # UPPER_CASE tag — fails ^[a-z0-9][a-z0-9-]*[a-z0-9]$
+  - tag: BAD_TAG_UPPER
+    description: "Tag has uppercase + underscore; must be rejected."

--- a/tests/loads_real_personas.rs
+++ b/tests/loads_real_personas.rs
@@ -3,6 +3,8 @@
 //! placeholder token, a quirk-tag syntax violation, or drifts between
 //! filename and `id`, this test fails before CI does.
 
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
 use aegis_hwsim::loader::{load_all, LoadOptions};
 use std::path::PathBuf;
 

--- a/tests/negative_fixtures.rs
+++ b/tests/negative_fixtures.rs
@@ -1,0 +1,112 @@
+//! Integration tests for the E1 loader guards. Each fixture under
+//! `tests/fixtures/bad-*.yaml` is copied into a fresh `personas/` dir
+//! (created in a temp tree) and `load_all()` must return the specific
+//! `LoadError` variant that guard was designed to catch.
+//!
+//! Tests are one-per-guard so a regression that breaks a single guard
+//! lands as a single failing test with a clear name.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use aegis_hwsim::loader::{load_all, LoadError, LoadOptions};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn fixture_path(filename: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(filename);
+    p
+}
+
+fn stage_fixture(fixture: &str) -> (tempfile::TempDir, LoadOptions) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let personas = tmp.path().join("personas");
+    let firmware = tmp.path().join("firmware");
+    fs::create_dir_all(&personas).expect("mkdir personas");
+    fs::create_dir_all(&firmware).expect("mkdir firmware");
+    let body = fs::read_to_string(fixture_path(fixture)).expect("read fixture");
+    let dest = personas.join(fixture);
+    fs::write(&dest, body).expect("write fixture copy");
+    let opts = LoadOptions {
+        personas_dir: personas,
+        firmware_root: firmware,
+    };
+    (tmp, opts)
+}
+
+fn fixture_abs_path(opts: &LoadOptions, fixture: &str) -> PathBuf {
+    opts.personas_dir.join(fixture)
+}
+
+fn assert_path_matches(got: &Path, opts: &LoadOptions, fixture: &str) {
+    let expected = fixture_abs_path(opts, fixture);
+    assert_eq!(got, expected, "error path should point at the fixture copy");
+}
+
+#[test]
+fn missing_schema_version_rejected_with_parse_error() {
+    let (_tmp, opts) = stage_fixture("bad-missing-schema-version.yaml");
+    let err = load_all(&opts).expect_err("expected LoadError");
+    match err {
+        LoadError::Parse { path, .. } => {
+            assert_path_matches(&path, &opts, "bad-missing-schema-version.yaml");
+        }
+        other => panic!("expected Parse, got {other:?}"),
+    }
+}
+
+#[test]
+fn placeholder_token_rejected() {
+    let (_tmp, opts) = stage_fixture("bad-placeholder-token.yaml");
+    let err = load_all(&opts).expect_err("expected LoadError");
+    match err {
+        LoadError::Placeholder { path, field } => {
+            assert_path_matches(&path, &opts, "bad-placeholder-token.yaml");
+            assert_eq!(field, "display_name");
+        }
+        other => panic!("expected Placeholder, got {other:?}"),
+    }
+}
+
+#[test]
+fn id_filename_drift_rejected() {
+    let (_tmp, opts) = stage_fixture("bad-id-filename-drift.yaml");
+    let err = load_all(&opts).expect_err("expected LoadError");
+    match err {
+        LoadError::IdMismatch {
+            path,
+            yaml_id,
+            filename_stem,
+        } => {
+            assert_path_matches(&path, &opts, "bad-id-filename-drift.yaml");
+            assert_eq!(yaml_id, "wrong-id-here");
+            assert_eq!(filename_stem, "bad-id-filename-drift");
+        }
+        other => panic!("expected IdMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn quirk_tag_with_uppercase_rejected() {
+    let (_tmp, opts) = stage_fixture("bad-quirk-tag-syntax.yaml");
+    let err = load_all(&opts).expect_err("expected LoadError");
+    match err {
+        LoadError::QuirkTag { path, tag } => {
+            assert_path_matches(&path, &opts, "bad-quirk-tag-syntax.yaml");
+            assert_eq!(tag, "BAD_TAG_UPPER");
+        }
+        other => panic!("expected QuirkTag, got {other:?}"),
+    }
+}
+
+#[test]
+fn custom_keyring_outside_root_rejected() {
+    let (_tmp, opts) = stage_fixture("bad-custom-keyring-traversal.yaml");
+    let err = load_all(&opts).expect_err("expected LoadError");
+    assert!(
+        matches!(err, LoadError::CustomKeyringOutsideRoot { .. }),
+        "expected CustomKeyringOutsideRoot, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds one fixture and one integration test per E1 loader guard. Each fixture lands under `tests/fixtures/bad-*.yaml` and is staged into a fresh temp `personas/` dir by `stage_fixture()` so the test hits the real `load_all()` entry point — not a private helper.

Closes #11. Completes the last coding task in E1 before JSONSchema export (#12).

## What's covered

| Guard | Fixture | Asserted `LoadError` |
|---|---|---|
| Parse | `bad-missing-schema-version.yaml` | `Parse { path, .. }` |
| Placeholder | `bad-placeholder-token.yaml` | `Placeholder { path, field == "display_name" }` |
| IdMismatch | `bad-id-filename-drift.yaml` | `IdMismatch { yaml_id == "wrong-id-here", filename_stem == "bad-id-filename-drift" }` |
| QuirkTag | `bad-quirk-tag-syntax.yaml` | `QuirkTag { tag == "BAD_TAG_UPPER" }` |
| CustomKeyringOutsideRoot | `bad-custom-keyring-traversal.yaml` | `CustomKeyringOutsideRoot { .. }` |

Every test asserts the error path points at the actual fixture copy in the temp dir, so a refactor that loses path context in an error variant lands as a failing assertion with a clear name.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --locked` — 17 total (11 unit + 1 real-persona + 5 negative-fixture)
- [ ] CI matrix green