### PR TITLE
feat(schema): JSONSchema export via gen-schema subcommand (E1.5, closes #12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,5 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test --locked
+      - name: Check JSONSchema is in sync with source
+        run: cargo run --locked -q --bin aegis-hwsim -- gen-schema --check schemas/persona.schema.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,9 @@ version = 4
 name = "aegis-hwsim"
 version = "0.0.1"
 dependencies = [
+ "schemars",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "thiserror",
@@ -29,6 +31,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -206,6 +214,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +267,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ path = "src/bin/aegis-hwsim.rs"
 # Minimal stack to start. We'll add as scenarios need them. No clap —
 # aegis-boot chose hand-rolled argv; stay consistent across the family.
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_yaml = "0.9"
+schemars = "0.8"
 thiserror = "2"
 
 [dev-dependencies]

--- a/schemas/persona.schema.json
+++ b/schemas/persona.schema.json
@@ -1,0 +1,421 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Persona",
+  "description": "Top-level persona YAML. One persona = one shipping hardware configuration.",
+  "type": "object",
+  "required": [
+    "display_name",
+    "dmi",
+    "id",
+    "schema_version",
+    "secure_boot",
+    "source",
+    "tpm",
+    "vendor"
+  ],
+  "properties": {
+    "display_name": {
+      "description": "Human-readable name shown in the coverage-grid output.",
+      "type": "string"
+    },
+    "dmi": {
+      "description": "DMI fields mapped 1:1 to `/sys/class/dmi/id/<field>` — QEMU's `-smbios` flags inject these at boot time.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Dmi"
+        }
+      ]
+    },
+    "id": {
+      "description": "Stable kebab-case identifier. Must match the YAML filename (without the `.yaml` extension).",
+      "type": "string"
+    },
+    "kernel": {
+      "description": "Kernel lockdown mode for the booted kernel.",
+      "default": {
+        "lockdown": "inherit"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Kernel"
+        }
+      ]
+    },
+    "quirks": {
+      "description": "Advisory list of vendor-specific quirks the harness can't simulate. Surfaced to the scenario runner so test reports can annotate \"this would work here but not on real hardware because X\".",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Quirk"
+      }
+    },
+    "scenarios": {
+      "description": "Per-scenario run/skip overrides. Opt-out is rare — prefer fixing the scenario over skipping it per-persona.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ScenarioDecision"
+      }
+    },
+    "schema_version": {
+      "description": "Pins the parser to an exact schema version. Mismatched parsers refuse to load the file. Bumped on breaking changes; additive fields don't bump it.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "secure_boot": {
+      "description": "Secure Boot posture to synthesize.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/SecureBoot"
+        }
+      ]
+    },
+    "source": {
+      "description": "Provenance record. Every persona must cite where its DMI + firmware values came from. See `Source` docs for accepted kinds.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Source"
+        }
+      ]
+    },
+    "tpm": {
+      "description": "TPM version to emulate via swtpm (or skip entirely).",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Tpm"
+        }
+      ]
+    },
+    "vendor": {
+      "description": "SMBIOS `sys_vendor` value verbatim as the vendor ships it. Preserve case (e.g. \"LENOVO\", \"Dell Inc.\", \"Framework\").",
+      "type": "string"
+    },
+    "year": {
+      "description": "Year the SKU first shipped. Optional but recommended — helps contributors understand firmware-era context.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint16",
+      "minimum": 0.0
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Dmi": {
+      "description": "DMI fields mapped to `/sys/class/dmi/id/<field>`. Everything QEMU's `-smbios type=0/1/2/3/...` injectors can populate.",
+      "type": "object",
+      "required": [
+        "bios_date",
+        "bios_vendor",
+        "bios_version",
+        "product_name",
+        "sys_vendor"
+      ],
+      "properties": {
+        "bios_date": {
+          "description": "Mapped to `/sys/class/dmi/id/bios_date` (MM/DD/YYYY).",
+          "type": "string"
+        },
+        "bios_vendor": {
+          "description": "Mapped to `/sys/class/dmi/id/bios_vendor`.",
+          "type": "string"
+        },
+        "bios_version": {
+          "description": "Mapped to `/sys/class/dmi/id/bios_version`.",
+          "type": "string"
+        },
+        "board_name": {
+          "description": "Mapped to `/sys/class/dmi/id/board_name`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "chassis_type": {
+          "description": "SMBIOS chassis type code (10 = notebook, 3 = desktop, 17 = main server chassis, etc.). See SMBIOS spec §7.4.1.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "product_name": {
+          "description": "Mapped to `/sys/class/dmi/id/product_name`. SKU code or friendly name per vendor convention (Lenovo puts the friendly name in `product_version`; Dell/HP put it here).",
+          "type": "string"
+        },
+        "product_version": {
+          "description": "Mapped to `/sys/class/dmi/id/product_version`. Lenovo convention.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sys_vendor": {
+          "description": "Mapped to `/sys/class/dmi/id/sys_vendor`.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Kernel": {
+      "description": "Kernel config for the booted kernel. `Default` leaves the initramfs kernel's lockdown mode unchanged.",
+      "type": "object",
+      "properties": {
+        "lockdown": {
+          "description": "Kernel lockdown mode. `Inherit` uses the initramfs kernel's default.",
+          "default": "inherit",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LockdownMode"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LockdownMode": {
+      "description": "Kernel lockdown mode (see `Documentation/admin-guide/LSM/LoadPin.rst` and the `lockdown` LSM).",
+      "oneOf": [
+        {
+          "description": "Use the initramfs kernel's built-in default.",
+          "type": "string",
+          "enum": [
+            "inherit"
+          ]
+        },
+        {
+          "description": "Lockdown disabled.",
+          "type": "string",
+          "enum": [
+            "none"
+          ]
+        },
+        {
+          "description": "Integrity mode — blocks kernel-integrity-breaking operations.",
+          "type": "string",
+          "enum": [
+            "integrity"
+          ]
+        },
+        {
+          "description": "Confidentiality mode — integrity + blocks kernel-memory reads.",
+          "type": "string",
+          "enum": [
+            "confidentiality"
+          ]
+        }
+      ]
+    },
+    "OvmfVariant": {
+      "description": "OVMF firmware variant.",
+      "oneOf": [
+        {
+          "description": "MS-enrolled VARs — the most common distro-shipped state.",
+          "type": "string",
+          "enum": [
+            "ms_enrolled"
+          ]
+        },
+        {
+          "description": "Custom PK/KEK/db from hwsim's test keyring. Tests the custom-CA enrollment path. Keys MUST carry `TEST_ONLY_NOT_FOR_PRODUCTION` in the CN per aegis-boot#226 security constraint #4.",
+          "type": "string",
+          "enum": [
+            "custom_pk"
+          ]
+        },
+        {
+          "description": "Setup mode — no PK enrolled. Operator MOK enrollment flow.",
+          "type": "string",
+          "enum": [
+            "setup_mode"
+          ]
+        },
+        {
+          "description": "SB off. Tests the \"aegis-boot refuses to flash\" diagnostic path.",
+          "type": "string",
+          "enum": [
+            "disabled"
+          ]
+        }
+      ]
+    },
+    "Quirk": {
+      "description": "A real-world quirk the harness can't simulate. Informational — exposed to scenarios so coverage reports can annotate \"this would work here but not on real hardware because X\".",
+      "type": "object",
+      "required": [
+        "description",
+        "tag"
+      ],
+      "properties": {
+        "description": {
+          "description": "Long-form description of the quirk and its operator impact.",
+          "type": "string"
+        },
+        "tag": {
+          "description": "Short grep-able tag. Must match `^[a-z0-9][a-z0-9-]*[a-z0-9]$`.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ScenarioDecision": {
+      "description": "Per-scenario run/skip decision.",
+      "oneOf": [
+        {
+          "description": "Scenario runs against this persona.",
+          "type": "string",
+          "enum": [
+            "run"
+          ]
+        },
+        {
+          "description": "Scenario skipped for this persona. Should be rare — prefer fixing the scenario over blanket-skipping it.",
+          "type": "string",
+          "enum": [
+            "skip"
+          ]
+        }
+      ]
+    },
+    "SecureBoot": {
+      "description": "Secure Boot posture the persona boots under.",
+      "type": "object",
+      "required": [
+        "ovmf_variant"
+      ],
+      "properties": {
+        "custom_keyring": {
+          "description": "When `ovmf_variant == CustomPk`, path to the hwsim-generated test keyring. Must be under `$AEGIS_HWSIM_ROOT/firmware/` — validated at load time per aegis-boot#226 security-engineer constraint #2.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ovmf_variant": {
+          "description": "Which OVMF variant to boot under.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OvmfVariant"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Source": {
+      "description": "Provenance citation for a persona. Every persona must cite its origin so reviewers can trace fields back to a primary source. Matches the `aegis-boot compat` DB's \"verified outcomes only\" stance.",
+      "type": "object",
+      "required": [
+        "kind",
+        "ref_"
+      ],
+      "properties": {
+        "captured_at": {
+          "description": "ISO-8601 date the persona's fields were captured/verified.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "kind": {
+          "description": "Kind of citation. See `SourceKind`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SourceKind"
+            }
+          ]
+        },
+        "ref_": {
+          "description": "Free-form reference. URL, issue number, spec-sheet title — whatever a reviewer can use to verify the persona's claims.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SourceKind": {
+      "description": "Kind of provenance citation. Ordered from highest to lowest confidence.",
+      "oneOf": [
+        {
+          "description": "Closed `hardware-report` GitHub issue from a real operator who ran the full flash → boot → kexec chain. Highest confidence.",
+          "type": "string",
+          "enum": [
+            "community_report"
+          ]
+        },
+        {
+          "description": "fwupd / LVFS firmware archive URL. Verified against vendor metadata.",
+          "type": "string",
+          "enum": [
+            "lvfs_catalog"
+          ]
+        },
+        {
+          "description": "Vendor-published spec sheet (Lenovo PSREF, Dell Product Support, Framework Marketplace). Lowest-confidence; use only for fields the other two don't cover.",
+          "type": "string",
+          "enum": [
+            "vendor_docs"
+          ]
+        }
+      ]
+    },
+    "Tpm": {
+      "description": "TPM emulation config. `None` variant means no TPM at all.",
+      "type": "object",
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "firmware_version": {
+          "description": "TPM2 firmware version string. Optional. Use when testing firmware-version-gated behavior.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "manufacturer": {
+          "description": "TPM2 manufacturer code (IFX, NTC, AMD, STM, INTC, ...). Optional; most tests don't care. Set when validating TPM2-FW-bug-specific paths.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "description": "TPM version, or `\"none\"` for no TPM. swtpm emulates 1.2 and 2.0.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TpmVersion"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TpmVersion": {
+      "description": "TPM version to emulate.",
+      "oneOf": [
+        {
+          "description": "No TPM present.",
+          "type": "string",
+          "enum": [
+            "none"
+          ]
+        },
+        {
+          "description": "TPM 1.2 (TIS interface).",
+          "type": "string",
+          "enum": [
+            "1.2"
+          ]
+        },
+        {
+          "description": "TPM 2.0 (TIS interface).",
+          "type": "string",
+          "enum": [
+            "2.0"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/bin/aegis-hwsim.rs
+++ b/src/bin/aegis-hwsim.rs
@@ -14,6 +14,7 @@ fn main() -> ExitCode {
     match args.first().map(String::as_str) {
         Some("list-personas") => run_list(&args[1..]),
         Some("validate") => run_validate(&args[1..]),
+        Some("gen-schema") => run_gen_schema(&args[1..]),
         Some("run") => {
             eprintln!("aegis-hwsim: run — not implemented yet");
             eprintln!("  Usage: aegis-hwsim run <persona> <scenario> <aegis-boot-stick.img>");
@@ -42,6 +43,7 @@ fn print_help() {
     println!("USAGE:");
     println!("  aegis-hwsim list-personas [--json]  List YAML fixtures under personas/");
     println!("  aegis-hwsim validate [--quiet]      Validate all personas against the schema");
+    println!("  aegis-hwsim gen-schema [--check]    Emit persona JSONSchema to stdout");
     println!("  aegis-hwsim run <persona> <scenario> <stick>");
     println!("                                      (not yet implemented — tracks #3)");
     println!("  aegis-hwsim --version               Print version");
@@ -232,6 +234,49 @@ fn json_escape(s: &str) -> String {
         }
     }
     out
+}
+
+/// `aegis-hwsim gen-schema` — emit the persona `JSONSchema` to stdout.
+/// With `--check <path>`, compare the generated schema against the file at
+/// `<path>` and exit 1 if they differ (CI drift-gate pattern).
+fn run_gen_schema(args: &[String]) -> ExitCode {
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+        println!("aegis-hwsim gen-schema — emit the persona JSONSchema");
+        println!();
+        println!("USAGE:");
+        println!("  aegis-hwsim gen-schema              # Print schema to stdout");
+        println!("  aegis-hwsim gen-schema --check PATH # Exit 1 if PATH differs from generated");
+        return ExitCode::SUCCESS;
+    }
+    let schema = schemars::schema_for!(aegis_hwsim::persona::Persona);
+    let Ok(rendered) = serde_json::to_string_pretty(&schema) else {
+        eprintln!("aegis-hwsim: failed to serialize schema");
+        return ExitCode::from(1);
+    };
+    let rendered = format!("{rendered}\n");
+    if let Some(idx) = args.iter().position(|a| a == "--check") {
+        let Some(path) = args.get(idx + 1) else {
+            eprintln!("aegis-hwsim gen-schema --check: missing PATH argument");
+            return ExitCode::from(2);
+        };
+        match std::fs::read_to_string(path) {
+            Ok(committed) if committed == rendered => ExitCode::SUCCESS,
+            Ok(_) => {
+                eprintln!(
+                    "aegis-hwsim: {path} is out of date. Run 'aegis-hwsim gen-schema > {path}' \
+                     and commit the result."
+                );
+                ExitCode::from(1)
+            }
+            Err(e) => {
+                eprintln!("aegis-hwsim: cannot read {path}: {e}");
+                ExitCode::from(1)
+            }
+        }
+    } else {
+        print!("{rendered}");
+        ExitCode::SUCCESS
+    }
 }
 
 /// Pretty-print a `LoadError` to stderr with operator-actionable context.

--- a/src/persona.rs
+++ b/src/persona.rs
@@ -4,11 +4,12 @@
 //! No runtime logic in this module beyond `serde` derivations — the
 //! schema is the contract, nothing more.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// Top-level persona YAML. One persona = one shipping hardware configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Persona {
     /// Pins the parser to an exact schema version. Mismatched parsers refuse
@@ -65,7 +66,7 @@ pub struct Persona {
 /// Provenance citation for a persona. Every persona must cite its origin so
 /// reviewers can trace fields back to a primary source. Matches the
 /// `aegis-boot compat` DB's "verified outcomes only" stance.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Source {
     /// Kind of citation. See `SourceKind`.
@@ -79,7 +80,7 @@ pub struct Source {
 }
 
 /// Kind of provenance citation. Ordered from highest to lowest confidence.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SourceKind {
     /// Closed `hardware-report` GitHub issue from a real operator who ran
@@ -95,7 +96,7 @@ pub enum SourceKind {
 
 /// DMI fields mapped to `/sys/class/dmi/id/<field>`. Everything QEMU's
 /// `-smbios type=0/1/2/3/...` injectors can populate.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Dmi {
     /// Mapped to `/sys/class/dmi/id/sys_vendor`.
@@ -123,7 +124,7 @@ pub struct Dmi {
 }
 
 /// Secure Boot posture the persona boots under.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SecureBoot {
     /// Which OVMF variant to boot under.
@@ -136,7 +137,7 @@ pub struct SecureBoot {
 }
 
 /// OVMF firmware variant.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum OvmfVariant {
     /// MS-enrolled VARs — the most common distro-shipped state.
@@ -152,7 +153,7 @@ pub enum OvmfVariant {
 }
 
 /// TPM emulation config. `None` variant means no TPM at all.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Tpm {
     /// TPM version, or `"none"` for no TPM. swtpm emulates 1.2 and 2.0.
@@ -168,7 +169,7 @@ pub struct Tpm {
 }
 
 /// TPM version to emulate.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum TpmVersion {
     /// No TPM present.
@@ -183,7 +184,7 @@ pub enum TpmVersion {
 
 /// Kernel config for the booted kernel. `Default` leaves the initramfs
 /// kernel's lockdown mode unchanged.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Kernel {
     /// Kernel lockdown mode. `Inherit` uses the initramfs kernel's default.
@@ -193,7 +194,7 @@ pub struct Kernel {
 
 /// Kernel lockdown mode (see `Documentation/admin-guide/LSM/LoadPin.rst`
 /// and the `lockdown` LSM).
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum LockdownMode {
     /// Use the initramfs kernel's built-in default.
@@ -210,7 +211,7 @@ pub enum LockdownMode {
 /// A real-world quirk the harness can't simulate. Informational — exposed
 /// to scenarios so coverage reports can annotate "this would work here
 /// but not on real hardware because X".
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Quirk {
     /// Short grep-able tag. Must match `^[a-z0-9][a-z0-9-]*[a-z0-9]$`.
@@ -220,7 +221,7 @@ pub struct Quirk {
 }
 
 /// Per-scenario run/skip decision.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ScenarioDecision {
     /// Scenario runs against this persona.

--- a/tests/schema_roundtrip.rs
+++ b/tests/schema_roundtrip.rs
@@ -1,0 +1,34 @@
+//! Round-trip test: `schemas/persona.schema.json` must match what
+//! `schemars::schema_for!(Persona)` currently produces. If a field is
+//! added/renamed and the committed schema isn't regenerated, this test
+//! fails locally before CI does. Regenerate via:
+//!
+//!     cargo run -q --bin aegis-hwsim -- gen-schema > schemas/persona.schema.json
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::fs;
+use std::path::PathBuf;
+
+#[test]
+fn committed_schema_matches_source() {
+    let schema = schemars::schema_for!(aegis_hwsim::persona::Persona);
+    let rendered = serde_json::to_string_pretty(&schema).unwrap();
+    let rendered = format!("{rendered}\n");
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("schemas");
+    path.push("persona.schema.json");
+    let committed = fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "could not read {}: {e}. Did you run `cargo run --bin aegis-hwsim -- gen-schema`?",
+            path.display()
+        )
+    });
+    assert_eq!(
+        committed,
+        rendered,
+        "schemas/persona.schema.json is out of date. \
+         Regenerate with: cargo run -q --bin aegis-hwsim -- gen-schema > schemas/persona.schema.json"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `JsonSchema` derives to every persona type and a new `aegis-hwsim gen-schema` subcommand that emits a draft-07 JSON schema to stdout. The committed `schemas/persona.schema.json` is what the current source produces; drift is guarded three ways.

Closes #12. This is the last Phase-1 coding task — E1 is now complete.

## What you can do with it

**IDE completion.** Point YAML-LS at the committed schema:

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/williamzujkowski/aegis-hwsim/main/schemas/persona.schema.json
schema_version: 1
id: my-persona
# …autocomplete kicks in
```

**CI drift gate.** Non-schema changes to `src/persona.rs` fail the build with a copy-pasteable fix:

```
aegis-hwsim: schemas/persona.schema.json is out of date.
Run 'aegis-hwsim gen-schema > schemas/persona.schema.json' and commit the result.
```

## Drift gates (3 layers)

| Layer | Mechanism | Fails on |
|---|---|---|
| Local unit test | `tests/schema_roundtrip.rs` | mismatch during `cargo test` |
| Local CLI | `gen-schema --check PATH` | exit 1 with fix hint |
| CI | workflow step 4 | same as above, blocks merge |

## Dependencies added

| Crate | Why |
|---|---|
| `schemars` 0.8 | `#[derive(JsonSchema)]` for all persona types |
| `serde_json` 1 | Pretty-print the generated schema |

No runtime dependency on schemars in the hot path — it's only touched by the `gen-schema` subcommand and the drift test.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --locked` — 18 tests (11 unit + 1 real-persona + 5 negative-fixture + 1 schema-roundtrip)
- [x] `aegis-hwsim gen-schema --check schemas/persona.schema.json` exits 0
- [ ] CI matrix green including new schema-drift step