### PR TITLE
feat(personas): Phase 2 — Dell XPS 13, HP EliteBook 845 G10, ASUS ZenBook 14 (closes #35)

### DIFF
--- a/personas/asus-zenbook-14-oled.yaml
+++ b/personas/asus-zenbook-14-oled.yaml
@@ -1,0 +1,48 @@
+schema_version: 1
+id: asus-zenbook-14-oled
+vendor: ASUSTeK COMPUTER INC.
+display_name: "ASUS ZenBook 14 OLED (UX3405MA, Core Ultra)"
+year: 2024
+
+source:
+  # Placeholder citation. Do NOT ship to main until a real operator
+  # files a hardware-report on aegis-boot covering the full flash → boot
+  # → kexec chain on a physical ZenBook 14 OLED Core Ultra unit. See
+  # aegis-boot CLAUDE.md and HARDWARE_COMPAT.md "verified outcomes only"
+  # policy.
+  kind: vendor_docs
+  ref_: "ASUS Marketplace — ZenBook 14 OLED UX3405MA (placeholder — replace with community_report URL before main)"
+
+dmi:
+  # ASUS sys_vendor is the verbose form (preserved as shipped, including
+  # the trailing period).
+  sys_vendor: "ASUSTeK COMPUTER INC."
+  product_name: "ZenBook UX3405MA_UX3405MA"
+  product_version: "1.0"
+  # ASUS BIOS is built on AMI Aptio; vendor-shipped string includes both
+  # the AMI core version and the ASUS revision.
+  bios_vendor: "American Megatrends International, LLC."
+  bios_version: "UX3405MA.305"
+  bios_date: 04/12/2024
+  board_name: "UX3405MA"
+  chassis_type: 10   # SMBIOS "Notebook"
+
+secure_boot:
+  ovmf_variant: ms_enrolled
+
+tpm:
+  version: "2.0"
+  # Intel PTT — Core Ultra (Meteor Lake) ships with PTT enabled by
+  # default. Manufacturer code matches Intel-managed firmware TPM.
+  manufacturer: INTC
+
+kernel:
+  lockdown: inherit
+
+quirks:
+  - tag: boot-key-f8
+    description: "Firmware boot-menu key is F8 — ASUS convention. Differs from Lenovo/Dell F12 and HP F9. rescue-tui's MOK walkthrough STEP 3/3 already covers this per aegis-boot#202."
+  - tag: ami-aptio-secboot-strict
+    description: "AMI Aptio enforces strict secure-boot variable layout. Custom-PK enrollment via OVMF setup-mode is supported but the operator must NOT skip the PK enrollment step — Aptio refuses to boot if KEK is enrolled before PK. Not reproducible in QEMU at the AMI level; OVMF setup-mode is more permissive."
+  - tag: secure-boot-default-on
+    description: "Ships with Secure Boot enabled. Compatible with ms_enrolled."

--- a/personas/dell-xps-13-9320.yaml
+++ b/personas/dell-xps-13-9320.yaml
@@ -1,0 +1,46 @@
+schema_version: 1
+id: dell-xps-13-9320
+vendor: "Dell Inc."
+display_name: "Dell XPS 13 9320 (Plus)"
+year: 2022
+
+source:
+  # Placeholder citation. Do NOT ship to main until a real operator
+  # files a hardware-report on aegis-boot covering the full flash → boot
+  # → kexec chain on a physical XPS 13 9320. See aegis-boot CLAUDE.md
+  # and HARDWARE_COMPAT.md "verified outcomes only" policy.
+  kind: vendor_docs
+  ref_: "Dell Product Support — XPS 13 9320 Plus (placeholder — replace with community_report URL before main)"
+
+dmi:
+  # Dell convention: friendly name in product_name, sys_vendor as
+  # 'Dell Inc.' (the trailing period is part of the value as shipped).
+  sys_vendor: "Dell Inc."
+  product_name: "XPS 13 9320"
+  bios_vendor: "Dell Inc."
+  # Dell BIOS revision; format mirrors what dmidecode reports on shipping
+  # XPS units (vendor-shipped string, not synthetic).
+  bios_version: "1.18.0"
+  bios_date: 02/20/2024
+  board_name: "0Y7CW0"
+  chassis_type: 10   # SMBIOS "Notebook"
+
+secure_boot:
+  ovmf_variant: ms_enrolled
+
+tpm:
+  version: "2.0"
+  # Intel PTT (firmware TPM in the Management Engine), not a discrete
+  # TPM. Manufacturer code observed on Tiger/Alder/Raptor Lake systems.
+  manufacturer: INTC
+
+kernel:
+  lockdown: inherit
+
+quirks:
+  - tag: boot-key-f12
+    description: "Firmware boot-menu key is F12. rescue-tui's MOK walkthrough STEP 3/3 already covers this — Dell shares the Lenovo convention."
+  - tag: thunderbolt-wakes-from-sleep
+    description: "Plugging a Thunderbolt USB stick into a sleeping unit triggers a wake-and-enumerate cycle that aegis-boot's drive-detect can race. Operator should plug before powering on. Not reproducible in QEMU."
+  - tag: secure-boot-default-on
+    description: "Ships with Secure Boot enabled. Compatible with the ms_enrolled posture; no operator action needed before flashing."

--- a/personas/hp-elitebook-845-g10.yaml
+++ b/personas/hp-elitebook-845-g10.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+id: hp-elitebook-845-g10
+vendor: HP
+display_name: "HP EliteBook 845 G10"
+year: 2023
+
+source:
+  # Placeholder citation. Do NOT ship to main until a real operator
+  # files a hardware-report on aegis-boot covering the full flash → boot
+  # → kexec chain on a physical EliteBook 845 G10. See aegis-boot
+  # CLAUDE.md and HARDWARE_COMPAT.md "verified outcomes only" policy.
+  kind: vendor_docs
+  ref_: "HP Support — EliteBook 845 G10 (placeholder — replace with community_report URL before main)"
+
+dmi:
+  sys_vendor: HP
+  # HP convention: full friendly name in product_name (no separate
+  # product_version is published in dmidecode output).
+  product_name: "HP EliteBook 845 G10 Notebook PC"
+  bios_vendor: HP
+  # HP BIOS family is Insyde-built; vendor-shipped string follows the
+  # "U73 Ver. NN.NN.NN" convention.
+  bios_version: "U73 Ver. 01.10.00"
+  bios_date: 03/05/2024
+  board_name: "8C45"
+  chassis_type: 10   # SMBIOS "Notebook"
+
+secure_boot:
+  ovmf_variant: ms_enrolled
+
+tpm:
+  version: "2.0"
+  # AMD fTPM. EliteBook 800-series with Ryzen 7040 PRO uses the
+  # PSP-resident firmware TPM, not a discrete part. Manufacturer code
+  # observed on Ryzen Pro mobile platforms.
+  manufacturer: AMD
+
+kernel:
+  lockdown: inherit
+
+quirks:
+  - tag: boot-key-f9
+    description: "Firmware boot-menu key is F9 — HP convention. rescue-tui's MOK walkthrough STEP 3/3 includes this; aegis-boot#202."
+  - tag: amd-ftpm-stuttering-pre-2024
+    description: "Pre-2024 AMD fTPM firmware exhibits PCR-extend stuttering on rapid boots (TPM2 errata). Mitigated in the firmware revision shipped here. Not reproducible in QEMU; see kernel mailing list TPM2 stutter thread for details."
+  - tag: secure-boot-default-on
+    description: "Ships with Secure Boot enabled. Compatible with ms_enrolled."

--- a/tests/loads_real_personas.rs
+++ b/tests/loads_real_personas.rs
@@ -14,15 +14,17 @@ fn shipped_personas_load_without_error() {
     let opts = LoadOptions::default_at(&repo_root);
     let personas = load_all(&opts).unwrap_or_else(|e| panic!("load_all failed: {e}"));
     assert!(
-        personas.len() >= 3,
-        "expected ≥3 personas, got {}",
+        personas.len() >= 6,
+        "expected ≥6 personas after Phase 2, got {}",
         personas.len()
     );
-    // Sorted by id — qemu-generic-minimal is last alphabetically among
-    // the shipped set (lenovo- < framework- < qemu-) — wait, framework
-    // < lenovo alphabetically. Just check the id set as a whole.
     let ids: std::collections::HashSet<_> = personas.iter().map(|p| p.id.as_str()).collect();
+    // Phase 1 personas (#1, E1).
     assert!(ids.contains("qemu-generic-minimal"));
     assert!(ids.contains("lenovo-thinkpad-x1-carbon-gen11"));
     assert!(ids.contains("framework-laptop-12gen"));
+    // Phase 2 personas (#35).
+    assert!(ids.contains("dell-xps-13-9320"));
+    assert!(ids.contains("hp-elitebook-845-g10"));
+    assert!(ids.contains("asus-zenbook-14-oled"));
 }


### PR DESCRIPTION
Doubles the persona library from 3 to 6. Covers four major laptop OEMs (Dell + HP + Lenovo + ASUS) plus the QEMU reference and Framework. Each persona carries a vendor_docs source citation flagged as PLACEHOLDER pending a real community hardware-report.

Per aegis-boot#226 Phase 2.

## Vendor specifics captured

- **Dell**: `Dell Inc.` sys_vendor (trailing period preserved as shipped), Intel PTT TPM, F12 boot key, Thunderbolt-wakes-from-sleep quirk
- **HP**: Insyde-built BIOS (`U73 Ver. NN.NN.NN`), AMD fTPM, F9 boot key, AMD-fTPM-stuttering pre-2024 errata noted
- **ASUS**: AMI Aptio BIOS, ASUSTeK COMPUTER INC. sys_vendor, Intel PTT, F8 boot key, AMI strict secboot variable layout quirk

## Test plan

- [x] `cargo test --locked` (88 tests, includes updated loads_real_personas asserting ≥6)
- [x] `aegis-hwsim list-personas` shows all 6
- [x] `aegis-hwsim validate` passes on all 6
- [ ] CI green