### PR TITLE
feat(coverage-grid): persona × scenario matrix + CI artifact (E4.1, closes #39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,19 @@ jobs:
       - run: cargo test --locked
       - name: Check JSONSchema is in sync with source
         run: cargo run --locked -q --bin aegis-hwsim -- gen-schema --check schemas/persona.schema.json
+      - name: Generate coverage-grid artifact
+        # Live grid (not --dry-run) — actually runs each cell. The
+        # smoke scenario will Pass against qemu-smoke-no-tpm; everything
+        # else Skips with a specific reason. Reviewers click the
+        # artifact to see the matrix shape for this PR.
+        run: |
+          mkdir -p artifacts
+          cargo run --locked -q --bin aegis-hwsim -- coverage-grid > artifacts/coverage-grid.md
+          cargo run --locked -q --bin aegis-hwsim -- coverage-grid --format json > artifacts/coverage-grid.json
+      - name: Upload coverage-grid artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-grid
+          path: artifacts/coverage-grid.*
+          retention-days: 30
+          if-no-files-found: error

--- a/src/bin/aegis-hwsim.rs
+++ b/src/bin/aegis-hwsim.rs
@@ -17,6 +17,7 @@ fn main() -> ExitCode {
         Some("gen-schema") => run_gen_schema(&args[1..]),
         Some("run") => run_scenario(&args[1..]),
         Some("list-scenarios") => run_list_scenarios(&args[1..]),
+        Some("coverage-grid") => run_coverage_grid(&args[1..]),
         Some("-h" | "--help" | "help") | None => {
             print_help();
             ExitCode::SUCCESS
@@ -43,6 +44,8 @@ fn print_help() {
     println!("  aegis-hwsim list-scenarios          List registered test scenarios");
     println!("  aegis-hwsim run <persona> <scenario> <stick.img> [--firmware-root DIR]");
     println!("                                      Run a scenario against a persona+stick");
+    println!("  aegis-hwsim coverage-grid [--format json|markdown] [--dry-run]");
+    println!("                                      Emit persona × scenario grid");
     println!("  aegis-hwsim --version               Print version");
     println!("  aegis-hwsim --help                  This message");
     println!();
@@ -274,6 +277,50 @@ fn run_gen_schema(args: &[String]) -> ExitCode {
         print!("{rendered}");
         ExitCode::SUCCESS
     }
+}
+
+/// `aegis-hwsim coverage-grid` — iterate personas × scenarios and emit
+/// the grid in the requested format. With `--dry-run`, every cell
+/// records `Skip { reason: "dry-run" }` without invoking the
+/// scenario; useful for fast CI artifacts.
+fn run_coverage_grid(args: &[String]) -> ExitCode {
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+        println!("aegis-hwsim coverage-grid — emit persona × scenario matrix");
+        println!();
+        println!("USAGE:");
+        println!("  aegis-hwsim coverage-grid [--format json|markdown] [--dry-run]");
+        println!();
+        println!("  --format markdown  Human-readable table (default)");
+        println!("  --format json      schema_version=1 envelope");
+        println!("  --dry-run          Skip every cell with reason='dry-run'");
+        return ExitCode::SUCCESS;
+    }
+    let format = if args.iter().any(|a| a == "json") {
+        aegis_hwsim::coverage_grid::OutputFormat::Json
+    } else {
+        aegis_hwsim::coverage_grid::OutputFormat::Markdown
+    };
+    let dry_run = args.iter().any(|a| a == "--dry-run");
+
+    let personas = match load_or_report() {
+        Ok(p) => p,
+        Err(code) => return ExitCode::from(code),
+    };
+    let registry = aegis_hwsim::scenario::Registry::default_set();
+
+    let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let cfg = aegis_hwsim::coverage_grid::GridConfig {
+        work_root: cwd.join("work").join("coverage-grid"),
+        firmware_root: PathBuf::from("/usr/share/OVMF"),
+        stick: PathBuf::from("/no/stick/configured"),
+        dry_run,
+    };
+    let cells = aegis_hwsim::coverage_grid::compute_grid(&personas, &registry, &cfg);
+    print!(
+        "{}",
+        aegis_hwsim::coverage_grid::render(&cells, &registry, format)
+    );
+    ExitCode::SUCCESS
 }
 
 /// `aegis-hwsim list-scenarios` — print the registered scenario names

--- a/src/coverage_grid.rs
+++ b/src/coverage_grid.rs
@@ -1,0 +1,474 @@
+//! Coverage-grid emitter.
+//!
+//! Iterates the persona library × scenario registry and produces a
+//! grid of results, one cell per combination. Two output formats:
+//!
+//! - **`OutputFormat::Json`** — `schema_version=1` envelope (matches
+//!   the `aegis-hwsim list-personas --json` family convention).
+//!   Suitable for downstream tooling.
+//! - **`OutputFormat::Markdown`** — human-readable table (rows =
+//!   personas, columns = scenarios, cells = PASS/FAIL/SKIP).
+//!
+//! The runner can operate in two modes:
+//!
+//! - **Live**: actually invokes each scenario. Slow on a runner with
+//!   real QEMU + signed sticks; useful for nightly CI.
+//! - **Dry-run**: every cell is recorded as `Skip { reason:
+//!   "dry-run" }` without invoking the scenario. Fast CI artifact —
+//!   shows the matrix shape + the prerequisites each scenario flags
+//!   as missing.
+//!
+//! No I/O on the file system beyond what scenarios themselves do.
+
+use crate::persona::Persona;
+use crate::scenario::{Registry, Scenario, ScenarioContext, ScenarioError, ScenarioResult};
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+/// One cell of the grid: result of running `scenario` against `persona`.
+#[derive(Debug, Clone)]
+pub struct GridCell {
+    /// Persona id (e.g. `lenovo-thinkpad-x1-carbon-gen11`).
+    pub persona_id: String,
+    /// Scenario name (e.g. `signed-boot-ubuntu`).
+    pub scenario_name: &'static str,
+    /// Either the typed result, or the runner-error message (Err
+    /// gets surfaced as a synthetic Fail cell so the grid stays
+    /// rectangular).
+    pub outcome: CellOutcome,
+    /// Wall-clock duration of the cell's run. Zero when `dry-run`.
+    pub duration: Duration,
+}
+
+/// Cell-level outcome. `RunnerError` is distinct from
+/// `Result(Fail{..})` because a runner error is a defect-to-fix
+/// (missing binary, bad stick path), not a test failure.
+#[derive(Debug, Clone)]
+pub enum CellOutcome {
+    /// Scenario completed and returned a typed result.
+    Result(ScenarioResult),
+    /// Scenario runner errored — render in the grid as a synthetic
+    /// FAIL with a "runner error: …" reason.
+    RunnerError(String),
+}
+
+impl CellOutcome {
+    /// One of `PASS`, `FAIL`, `SKIP`, or `ERROR` (synthetic).
+    #[must_use]
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Result(r) => r.label(),
+            Self::RunnerError(_) => "ERROR",
+        }
+    }
+    /// One-line operator-facing reason (or empty for `Pass`).
+    #[must_use]
+    pub fn reason(&self) -> &str {
+        match self {
+            Self::Result(r) => r.reason(),
+            Self::RunnerError(msg) => msg,
+        }
+    }
+}
+
+/// Output format selected via the CLI flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    /// `schema_version=1` JSON envelope.
+    Json,
+    /// Human-readable Markdown table.
+    Markdown,
+}
+
+/// Configuration for [`compute_grid`].
+#[derive(Debug, Clone)]
+pub struct GridConfig {
+    /// Per-cell working dir parent. Each cell gets a subdirectory
+    /// `<work_root>/<persona-id>__<scenario-name>/`.
+    pub work_root: PathBuf,
+    /// Firmware-root passed into every scenario context.
+    pub firmware_root: PathBuf,
+    /// Stick path passed into every scenario context. Most scenarios
+    /// will Skip on a non-existent path (which is the point under
+    /// dry-run).
+    pub stick: PathBuf,
+    /// `true` → record every cell as `Skip { reason: "dry-run" }`
+    /// without invoking the scenario.
+    pub dry_run: bool,
+}
+
+/// Compute the grid: one cell per (persona, scenario) combination.
+/// Personas iterated in the order [`crate::loader::load_all`] returns
+/// (sorted by id); scenarios iterated in registration order.
+#[must_use]
+pub fn compute_grid(personas: &[Persona], registry: &Registry, cfg: &GridConfig) -> Vec<GridCell> {
+    let mut cells = Vec::with_capacity(personas.len() * registry.len());
+    for persona in personas {
+        for (scenario_name, _) in registry.iter() {
+            // `find` is guaranteed Some here because we just iterated
+            // the same registry; if a future refactor breaks that
+            // invariant, fall through with a synthetic ERROR cell
+            // rather than panicking.
+            let Some(scenario) = registry.find(scenario_name) else {
+                cells.push(GridCell {
+                    persona_id: persona.id.clone(),
+                    scenario_name,
+                    outcome: CellOutcome::RunnerError(
+                        "internal: registry iter/find disagreement".to_string(),
+                    ),
+                    duration: Duration::ZERO,
+                });
+                continue;
+            };
+            let cell = run_one_cell(persona, scenario, cfg);
+            cells.push(cell);
+        }
+    }
+    cells
+}
+
+fn run_one_cell(persona: &Persona, scenario: &dyn Scenario, cfg: &GridConfig) -> GridCell {
+    let cell_work_dir = cfg
+        .work_root
+        .join(format!("{}__{}", persona.id, scenario.name()));
+
+    if cfg.dry_run {
+        return GridCell {
+            persona_id: persona.id.clone(),
+            scenario_name: scenario.name(),
+            outcome: CellOutcome::Result(ScenarioResult::Skip {
+                reason: "dry-run".to_string(),
+            }),
+            duration: Duration::ZERO,
+        };
+    }
+
+    let ctx = ScenarioContext {
+        persona: persona.clone(),
+        stick: cfg.stick.clone(),
+        work_dir: cell_work_dir,
+        firmware_root: cfg.firmware_root.clone(),
+    };
+
+    let start = Instant::now();
+    let outcome = match scenario.run(&ctx) {
+        Ok(r) => CellOutcome::Result(r),
+        Err(e) => CellOutcome::RunnerError(format_runner_error(&e)),
+    };
+    let duration = start.elapsed();
+
+    GridCell {
+        persona_id: persona.id.clone(),
+        scenario_name: scenario.name(),
+        outcome,
+        duration,
+    }
+}
+
+fn format_runner_error(e: &ScenarioError) -> String {
+    format!("runner error: {e}")
+}
+
+/// Render a grid in the requested format. Markdown is operator-facing
+/// (sticky column = persona id, columns = scenario names); JSON is the
+/// `schema_version=1` envelope.
+#[must_use]
+pub fn render(cells: &[GridCell], registry: &Registry, format: OutputFormat) -> String {
+    match format {
+        OutputFormat::Json => render_json(cells),
+        OutputFormat::Markdown => render_markdown(cells, registry),
+    }
+}
+
+fn render_json(cells: &[GridCell]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(cells.len() * 200);
+    out.push_str("{\n");
+    out.push_str("  \"schema_version\": 1,\n");
+    out.push_str("  \"tool\": \"aegis-hwsim\",\n");
+    let _ = writeln!(out, "  \"tool_version\": \"{}\",", env!("CARGO_PKG_VERSION"));
+    out.push_str("  \"cells\": [\n");
+    let last = cells.len().saturating_sub(1);
+    for (i, c) in cells.iter().enumerate() {
+        let comma = if i == last { "" } else { "," };
+        out.push_str("    {\n");
+        let _ = writeln!(
+            out,
+            "      \"persona_id\": \"{}\",",
+            json_escape(&c.persona_id)
+        );
+        let _ = writeln!(
+            out,
+            "      \"scenario_name\": \"{}\",",
+            json_escape(c.scenario_name)
+        );
+        let _ = writeln!(out, "      \"result\": \"{}\",", c.outcome.label());
+        let _ = writeln!(
+            out,
+            "      \"reason\": \"{}\",",
+            json_escape(c.outcome.reason())
+        );
+        let _ = writeln!(out, "      \"duration_ms\": {}", c.duration.as_millis());
+        let _ = writeln!(out, "    }}{comma}");
+    }
+    out.push_str("  ]\n");
+    out.push_str("}\n");
+    out
+}
+
+fn render_markdown(cells: &[GridCell], registry: &Registry) -> String {
+    use std::fmt::Write as _;
+    let scenarios: Vec<&'static str> = registry.iter().map(|(n, _)| n).collect();
+    let mut personas: Vec<String> = cells.iter().map(|c| c.persona_id.clone()).collect();
+    personas.sort();
+    personas.dedup();
+
+    let mut out = String::with_capacity(cells.len() * 80);
+    out.push_str("# aegis-hwsim coverage grid\n\n");
+    let _ = writeln!(
+        out,
+        "{} persona(s) × {} scenario(s) = {} cell(s).\n",
+        personas.len(),
+        scenarios.len(),
+        cells.len()
+    );
+    // Header row.
+    out.push_str("| persona |");
+    for s in &scenarios {
+        let _ = write!(out, " {s} |");
+    }
+    out.push('\n');
+    // Separator.
+    out.push_str("|---|");
+    for _ in &scenarios {
+        out.push_str("---|");
+    }
+    out.push('\n');
+    // Data rows.
+    for p in &personas {
+        let _ = write!(out, "| {p} |");
+        for s in &scenarios {
+            let cell = cells
+                .iter()
+                .find(|c| c.persona_id == *p && c.scenario_name == *s);
+            let label = cell.map_or("?", |c| c.outcome.label());
+            let _ = write!(out, " {label} |");
+        }
+        out.push('\n');
+    }
+    out.push('\n');
+    // Reasons section — gives the operator the SKIP/FAIL details
+    // without bloating the table.
+    out.push_str("## Cell details\n\n");
+    for c in cells {
+        let r = c.outcome.reason();
+        if r.is_empty() {
+            continue;
+        }
+        let _ = writeln!(
+            out,
+            "- `{}` × `{}` — **{}**: {}",
+            c.persona_id,
+            c.scenario_name,
+            c.outcome.label(),
+            r
+        );
+    }
+    out
+}
+
+/// Minimal JSON string escape — covers `"`, `\`, control chars, newline,
+/// tab. Matches the existing pattern in `aegis-hwsim list-personas
+/// --json` so the family parses uniformly.
+fn json_escape(s: &str) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn fake_persona(id: &str) -> Persona {
+        let yaml = format!(
+            "
+schema_version: 1
+id: {id}
+vendor: QEMU
+display_name: {id}
+source:
+  kind: vendor_docs
+  ref_: test
+dmi:
+  sys_vendor: QEMU
+  product_name: Standard PC
+  bios_vendor: EDK II
+  bios_version: stable
+  bios_date: 01/01/2024
+secure_boot:
+  ovmf_variant: ms_enrolled
+tpm:
+  version: none
+"
+        );
+        serde_yaml::from_str(&yaml).unwrap()
+    }
+
+    /// A minimal scenario for grid tests — always returns the result
+    /// it was constructed with.
+    struct CannedScenario {
+        name: &'static str,
+        result: ScenarioResult,
+    }
+    impl Scenario for CannedScenario {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        fn description(&self) -> &'static str {
+            "test"
+        }
+        fn run(&self, _ctx: &ScenarioContext) -> Result<ScenarioResult, ScenarioError> {
+            Ok(self.result.clone())
+        }
+    }
+
+    fn fake_cfg() -> GridConfig {
+        GridConfig {
+            work_root: tempfile::tempdir().unwrap().path().to_path_buf(),
+            firmware_root: PathBuf::from("/usr/share/OVMF"),
+            stick: PathBuf::from("/no/such/stick"),
+            dry_run: false,
+        }
+    }
+
+    #[test]
+    fn dry_run_skips_every_cell_without_invoking_scenarios() {
+        let mut r = Registry::empty();
+        // If the scenario actually ran, this would Pass — but dry-run
+        // should preempt and emit Skip.
+        r.register(Box::new(CannedScenario {
+            name: "x",
+            result: ScenarioResult::Pass,
+        }));
+        let p = vec![fake_persona("a"), fake_persona("b")];
+        let mut cfg = fake_cfg();
+        cfg.dry_run = true;
+        let cells = compute_grid(&p, &r, &cfg);
+        assert_eq!(cells.len(), 2);
+        for cell in &cells {
+            assert_eq!(cell.outcome.label(), "SKIP");
+            assert_eq!(cell.outcome.reason(), "dry-run");
+            assert_eq!(cell.duration, Duration::ZERO);
+        }
+    }
+
+    #[test]
+    fn live_grid_runs_each_combination() {
+        let mut r = Registry::empty();
+        r.register(Box::new(CannedScenario {
+            name: "alpha",
+            result: ScenarioResult::Pass,
+        }));
+        r.register(Box::new(CannedScenario {
+            name: "beta",
+            result: ScenarioResult::Fail {
+                reason: "test-fail".into(),
+            },
+        }));
+        let p = vec![fake_persona("p1"), fake_persona("p2")];
+        let cells = compute_grid(&p, &r, &fake_cfg());
+        // 2 personas × 2 scenarios = 4 cells.
+        assert_eq!(cells.len(), 4);
+        // Two PASS, two FAIL — order: (p1,alpha) PASS, (p1,beta) FAIL,
+        // (p2,alpha) PASS, (p2,beta) FAIL.
+        assert_eq!(cells[0].outcome.label(), "PASS");
+        assert_eq!(cells[1].outcome.label(), "FAIL");
+        assert_eq!(cells[1].outcome.reason(), "test-fail");
+        assert_eq!(cells[2].outcome.label(), "PASS");
+        assert_eq!(cells[3].outcome.label(), "FAIL");
+    }
+
+    #[test]
+    fn render_json_emits_schema_version_envelope() {
+        let cells = vec![GridCell {
+            persona_id: "p1".into(),
+            scenario_name: "scenario-x",
+            outcome: CellOutcome::Result(ScenarioResult::Pass),
+            duration: Duration::from_millis(1234),
+        }];
+        let json = render_json(&cells);
+        assert!(json.contains("\"schema_version\": 1"));
+        assert!(json.contains("\"tool\": \"aegis-hwsim\""));
+        assert!(json.contains("\"persona_id\": \"p1\""));
+        assert!(json.contains("\"scenario_name\": \"scenario-x\""));
+        assert!(json.contains("\"result\": \"PASS\""));
+        assert!(json.contains("\"duration_ms\": 1234"));
+    }
+
+    #[test]
+    fn render_markdown_includes_table_and_reasons_section() {
+        let mut r = Registry::empty();
+        r.register(Box::new(CannedScenario {
+            name: "smoke",
+            result: ScenarioResult::Skip {
+                reason: "missing dep".into(),
+            },
+        }));
+        let cells = vec![GridCell {
+            persona_id: "alpha".into(),
+            scenario_name: "smoke",
+            outcome: CellOutcome::Result(ScenarioResult::Skip {
+                reason: "missing dep".into(),
+            }),
+            duration: Duration::from_millis(5),
+        }];
+        let md = render_markdown(&cells, &r);
+        assert!(md.contains("# aegis-hwsim coverage grid"));
+        assert!(md.contains("| persona |"));
+        assert!(md.contains("| smoke |"));
+        assert!(md.contains("| alpha |"));
+        assert!(md.contains("SKIP"));
+        assert!(md.contains("missing dep"));
+    }
+
+    #[test]
+    fn runner_error_renders_as_synthetic_error_cell() {
+        struct ErroringScenario;
+        impl Scenario for ErroringScenario {
+            fn name(&self) -> &'static str {
+                "broken"
+            }
+            fn description(&self) -> &'static str {
+                "broken"
+            }
+            fn run(&self, _ctx: &ScenarioContext) -> Result<ScenarioResult, ScenarioError> {
+                Err(ScenarioError::UnsupportedPersona {
+                    scenario: "broken",
+                    persona: "any".into(),
+                    reason: "test".into(),
+                })
+            }
+        }
+        let mut r = Registry::empty();
+        r.register(Box::new(ErroringScenario));
+        let cells = compute_grid(&[fake_persona("p")], &r, &fake_cfg());
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].outcome.label(), "ERROR");
+        assert!(cells[0].outcome.reason().contains("runner error"));
+    }
+}

--- a/src/coverage_grid.rs
+++ b/src/coverage_grid.rs
@@ -186,7 +186,11 @@ fn render_json(cells: &[GridCell]) -> String {
     out.push_str("{\n");
     out.push_str("  \"schema_version\": 1,\n");
     out.push_str("  \"tool\": \"aegis-hwsim\",\n");
-    let _ = writeln!(out, "  \"tool_version\": \"{}\",", env!("CARGO_PKG_VERSION"));
+    let _ = writeln!(
+        out,
+        "  \"tool_version\": \"{}\",",
+        env!("CARGO_PKG_VERSION")
+    );
     out.push_str("  \"cells\": [\n");
     let last = cells.len().saturating_sub(1);
     for (i, c) in cells.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod coverage_grid;
 pub mod loader;
 pub mod ovmf;
 pub mod persona;

--- a/src/scenarios/qemu_boots_ovmf.rs
+++ b/src/scenarios/qemu_boots_ovmf.rs
@@ -59,15 +59,15 @@ impl Scenario for QemuBootsOvmf {
 
         // The persona MUST opt out of TPM. The smoke scenario is the
         // harness self-test; mixing in swtpm would just expand the
-        // failure surface without adding signal. Reject up front so the
-        // operator gets a clear "use qemu-smoke-no-tpm" message.
+        // failure surface without adding signal. Skip (not Fail) when
+        // a TPM persona is handed in so the coverage grid renders this
+        // as N/A — most personas legitimately request TPM, and that
+        // shouldn't pollute the grid with FAIL/ERROR noise.
         if !matches!(ctx.persona.tpm.version, crate::persona::TpmVersion::None) {
-            return Err(ScenarioError::UnsupportedPersona {
-                scenario: "qemu-boots-ovmf",
-                persona: ctx.persona.id.clone(),
+            return Ok(ScenarioResult::Skip {
                 reason: format!(
-                    "qemu-boots-ovmf is a no-TPM smoke; persona {} requests TPM {:?}. \
-                     Use the qemu-smoke-no-tpm persona for harness self-test.",
+                    "scenario is no-TPM only; persona {} requests TPM {:?}. \
+                     The qemu-smoke-no-tpm persona exercises this scenario.",
                     ctx.persona.id, ctx.persona.tpm.version
                 ),
             });
@@ -186,7 +186,7 @@ tpm:
     }
 
     #[test]
-    fn rejects_persona_with_tpm() {
+    fn skips_persona_with_tpm() {
         let s = QemuBootsOvmf;
         let mut p = no_tpm_persona();
         p.tpm.version = crate::persona::TpmVersion::Tpm20;
@@ -196,10 +196,13 @@ tpm:
             work_dir: tempfile::tempdir().unwrap().path().to_path_buf(),
             firmware_root: PathBuf::from("/usr/share/OVMF"),
         };
-        let err = s.run(&ctx).unwrap_err();
-        assert!(
-            matches!(err, ScenarioError::UnsupportedPersona { .. }),
-            "expected UnsupportedPersona, got {err:?}"
-        );
+        let result = s.run(&ctx).unwrap();
+        match result {
+            ScenarioResult::Skip { reason } => {
+                assert!(reason.contains("no-TPM only"), "got reason: {reason}");
+                assert!(reason.contains("qemu-smoke-no-tpm"));
+            }
+            other => panic!("expected Skip, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

\`aegis-hwsim coverage-grid [--format json|markdown] [--dry-run]\` iterates the 7-persona library × the scenario registry and emits one cell per combination. CI now publishes the result as a build artifact every PR — reviewers click to see the matrix shape for that change.

Closes #39 (E4.1). Part of #4 (E4 epic).

## What it looks like

\`\`\`
$ aegis-hwsim coverage-grid
# aegis-hwsim coverage grid

7 persona(s) × 2 scenario(s) = 14 cell(s).

| persona | qemu-boots-ovmf | signed-boot-ubuntu |
|---|---|---|
| asus-zenbook-14-oled | SKIP | SKIP |
| dell-xps-13-9320 | SKIP | SKIP |
| framework-laptop-12gen | SKIP | SKIP |
| hp-elitebook-845-g10 | SKIP | SKIP |
| lenovo-thinkpad-x1-carbon-gen11 | SKIP | SKIP |
| qemu-generic-minimal | SKIP | SKIP |
| qemu-smoke-no-tpm | PASS | SKIP |

## Cell details
- ... (one bullet per non-empty reason)
\`\`\`

JSON output is a \`schema_version=1\` envelope with one entry per cell — \`persona_id\`, \`scenario_name\`, \`result\`, \`reason\`, \`duration_ms\`. Matches the \`aegis-hwsim list-personas --json\` family convention.

## Bug fix bundled

While running the live grid I noticed \`qemu-boots-ovmf\` was returning \`UnsupportedPersona\` for TPM personas, which the grid renders as \`ERROR\` — visually noisy and semantically wrong (most personas legitimately request TPM; that's not a defect). Changed to return \`Skip{reason}\` instead. The grid now shows clean SKIPs.

## CI artifact wiring

The CI workflow now runs the live grid + uploads both formats:

\`\`\`yaml
- name: Generate coverage-grid artifact
  run: |
    cargo run --bin aegis-hwsim -- coverage-grid > artifacts/coverage-grid.md
    cargo run --bin aegis-hwsim -- coverage-grid --format json > artifacts/coverage-grid.json
- name: Upload coverage-grid artifact
  uses: actions/upload-artifact@v4
  with:
    name: coverage-grid
    path: artifacts/coverage-grid.*
    retention-days: 30
\`\`\`

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test --locked\` (97 tests including 5 new coverage-grid)
- [x] \`coverage-grid --dry-run\` returns SKIP for every cell
- [x] \`coverage-grid\` (live) returns PASS for qemu-smoke-no-tpm × qemu-boots-ovmf, SKIPs otherwise
- [x] \`coverage-grid --format json\` emits valid JSON (parseable by \`python3 -m json.tool\`)
- [ ] CI green; artifact appears under the run's "Artifacts" section