### PR TITLE
feat(doctor): host-environment check + contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to aegis-hwsim
+
+Thanks for considering a contribution. This is the test harness for [aegis-boot](https://github.com/williamzujkowski/aegis-boot)'s signed-chain USB-rescue flow; the bar for changes is "would you trust this in your boot path?"
+
+## Quickstart for first-time contributors
+
+```bash
+# Verify your host has everything we need
+cargo run --release --bin aegis-hwsim -- doctor
+
+# Build + test
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --locked
+
+# See the matrix this build would run
+cargo run --release --bin aegis-hwsim -- coverage-grid
+```
+
+If `doctor` flags FAIL, fix that first; most issues are missing apt packages (`qemu-system-x86`, `ovmf`, `swtpm`).
+
+## What we accept
+
+| Type of change | Accepted? | Notes |
+|---|---|---|
+| New persona for a real shipping laptop | Yes | See [docs/persona-authoring.md](docs/persona-authoring.md). Source citation required. |
+| New scenario asserting a boot-flow invariant | Yes | See [docs/scenario-authoring.md](docs/scenario-authoring.md). Must register in `Registry::default_set`. |
+| New test for an existing module | Yes | Especially edge cases the fuzz didn't catch. |
+| Refactor that improves clarity | Yes | Must keep all existing tests green + add a test if it caught a real defect. |
+| Refactor "for cleanness" with no test improvement | No | We avoid churn. See aegis-boot CLAUDE.md "refactor threshold" §. |
+| New dependency | Discuss first | Open an issue. The crate currently uses serde, serde_json, serde_yaml, schemars, thiserror, and tempfile (dev). Each addition is justified. |
+| New CLI subcommand | Yes if scoped | Must have a `--help` line + `print_help` entry. |
+
+## Source-citation policy
+
+Every external claim — README, design docs, persona quirks — links to a primary source. The `personas/` policy is strict:
+
+- Real persona = `kind: community_report` with a closed `hardware-report` issue URL on the aegis-boot repo, AND a real operator confirmed the full flash → boot → kexec chain works.
+- Otherwise = `kind: vendor_docs` with the source flagged as "PLACEHOLDER pending a real community hardware-report" in a comment.
+
+This matches the [aegis-boot compat DB policy](https://github.com/williamzujkowski/aegis-boot/blob/main/docs/HARDWARE_COMPAT.md): **verified outcomes only**.
+
+## Lint policy
+
+- `unsafe_code = "forbid"` (workspace).
+- `unwrap_used = "deny"` and `expect_used = "deny"` in production code. Tests opt back out at the `#[cfg(test)] mod tests` boundary with `#![allow(clippy::unwrap_used, clippy::expect_used)]`.
+- All clippy lints must pass under `-D warnings`. CI runs `cargo clippy --all-targets -- -D warnings`.
+- `cargo fmt --check` must pass. Run `cargo fmt` before pushing — CI's nightly rustfmt sometimes wraps long lines that local stable rustfmt doesn't, so your local fmt may not catch everything until CI.
+
+## Pull request flow
+
+1. Branch off `main`: `git checkout -b feat/<short-description>` or `fix/<short>` or `docs/<short>`.
+2. Commit with a Conventional-Commits prefix: `feat(persona):`, `fix(qemu):`, `test(fuzz):`, `docs(readme):`, etc.
+3. Run the full local validation: `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test --locked`.
+4. Push + open the PR. Title in present tense, summary under 200 characters.
+5. The PR description should include a **Test plan** checklist mirroring the family pattern; see merged PRs for examples.
+
+## Co-author footer
+
+The aegis family uses a `Co-Authored-By:` footer on every commit. Pick the form matching your contribution:
+
+```
+Co-Authored-By: Your Name <your@email>
+```
+
+For AI-assisted contributions, use the upstream form (we use Claude in this project):
+
+```
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+## CI matrix
+
+Every PR runs:
+
+- `cargo fmt --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test --locked` (90+ tests including 60k random-input fuzz)
+- `aegis-hwsim gen-schema --check schemas/persona.schema.json` — drift gate
+- `aegis-hwsim coverage-grid` — outputs the matrix as a build artifact (markdown + JSON)
+- The `qemu-boots-ovmf` smoke scenario actually spawns QEMU+OVMF and asserts BdsDxe reaches serial — proves the harness wiring on every PR
+
+CI install footprint: `qemu-system-x86 ovmf` via apt. We deliberately don't install `swtpm` in CI yet because the smoke scenario uses a `TpmVersion::None` persona — when we add a TPM-bearing scenario that runs without a signed stick, we'll add swtpm to CI then.
+
+## Scope reminders
+
+We **do** validate:
+
+- DMI / SMBIOS strings the kernel exposes at `/sys/class/dmi/id/`
+- Secure Boot postures via OVMF variants (MS-enrolled / custom-PK / setup-mode / disabled)
+- TPM 1.2 / 2.0 presence via swtpm
+- Kernel lockdown modes
+- aegis-boot's signed-chain assertions
+
+We **do not** validate (out of scope):
+
+- Vendor UEFI UI flows (Lenovo blue MOK Manager, Dell F12, HP Fast Boot)
+- Kernel vendor-quirk paths (`thinkpad_acpi`, `dell-laptop`, etc.)
+- EC quirks, USB controller firmware, hardware errata
+- UEFI firmware fuzzing (use [chipsec](https://github.com/chipsec/chipsec))
+
+If you propose a change that crosses into out-of-scope territory, that's not necessarily a no — but please open a discussion issue first so we can decide if it warrants expanding scope.

--- a/docs/persona-authoring.md
+++ b/docs/persona-authoring.md
@@ -1,0 +1,138 @@
+# Authoring a new persona
+
+A **persona** is a YAML fixture that captures the DMI fields, Secure Boot posture, TPM configuration, and vendor-specific quirks of one shipping hardware configuration. Adding one expands the harness coverage matrix without requiring physical hardware in CI.
+
+## Where it lives
+
+`personas/<id>.yaml`. The filename stem MUST equal the YAML's `id` field — the loader rejects drift.
+
+## Schema reference
+
+Authoritative schema: `schemas/persona.schema.json` (auto-generated from `src/persona.rs`). IDE YAML-LS plugins can pull this for autocomplete:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/williamzujkowski/aegis-hwsim/main/schemas/persona.schema.json
+schema_version: 1
+id: my-vendor-my-model
+# ...
+```
+
+Drift between the source schema and the committed JSON is gated by CI; if you change `src/persona.rs`, regenerate via:
+
+```bash
+cargo run --bin aegis-hwsim -- gen-schema > schemas/persona.schema.json
+```
+
+## Required fields
+
+```yaml
+schema_version: 1
+id: kebab-case-id-matching-filename
+vendor: "Vendor Name (preserve as shipped)"
+display_name: "Human-readable model name"
+source:
+  kind: vendor_docs   # or community_report, lvfs_catalog
+  ref_: "URL or spec-sheet title — must be verifiable"
+dmi:
+  sys_vendor: ...
+  product_name: ...
+  bios_vendor: ...
+  bios_version: ...
+  bios_date: MM/DD/YYYY
+secure_boot:
+  ovmf_variant: ms_enrolled  # or custom_pk, setup_mode, disabled
+tpm:
+  version: "2.0"  # or "1.2", "none"
+```
+
+Optional fields: `year`, `dmi.product_version`, `dmi.board_name`, `dmi.chassis_type`, `tpm.manufacturer`, `tpm.firmware_version`, `kernel.lockdown`, `quirks[]`, `scenarios{}`.
+
+## Source-citation policy (strict)
+
+The `source` block decides whether a persona ships:
+
+| `kind` | When to use | Required `ref_` content |
+|---|---|---|
+| `community_report` | A real operator ran the full flash → boot → kexec chain on physical hardware AND filed a hardware-report on aegis-boot. | URL of the closed hardware-report issue. |
+| `lvfs_catalog` | DMI values verified against fwupd / LVFS firmware archive metadata. | Direct LVFS catalog URL. |
+| `vendor_docs` | Vendor PSREF / spec sheet. **Lowest confidence; flag as PLACEHOLDER.** | Spec-sheet title + a comment in the YAML stating this needs replacement. |
+
+A `vendor_docs` persona MUST include a comment block above `source:` like:
+
+```yaml
+source:
+  # Placeholder citation. Do NOT ship to main until a real operator
+  # files a hardware-report on aegis-boot covering the full flash → boot
+  # → kexec chain on physical hardware. See aegis-boot CLAUDE.md and
+  # HARDWARE_COMPAT.md "verified outcomes only" policy.
+  kind: vendor_docs
+  ref_: "Vendor spec sheet URL or title (placeholder)"
+```
+
+This matches the [aegis-boot compat DB](https://github.com/williamzujkowski/aegis-boot/blob/main/docs/HARDWARE_COMPAT.md) policy and prevents accidentally claiming verified coverage we don't have.
+
+## DMI fields — capture-as-shipped
+
+Preserve vendor strings **verbatim**, including trailing periods, capitalization, and whitespace:
+
+| Vendor | sys_vendor (literal) | product_name convention |
+|---|---|---|
+| Lenovo | `LENOVO` | SKU code (`21HMCTO1WW`); friendly name in `product_version` (`ThinkPad X1 Carbon Gen 11`) |
+| Dell | `Dell Inc.` (trailing period) | Friendly name (`XPS 13 9320`) |
+| HP | `HP` | Full friendly name including `Notebook PC` suffix |
+| ASUS | `ASUSTeK COMPUTER INC.` (trailing period) | Internal SKU (`ZenBook UX3405MA_UX3405MA`) |
+| Framework | `Framework` | `Laptop` + chassis revision |
+| QEMU | `QEMU` | `Standard PC (Q35 + ICH9, 2009)` etc. |
+
+Capture these from `sudo dmidecode -t system -t bios -t baseboard -t chassis` on a real unit, not from marketing material.
+
+## Quirk tags
+
+Add a `quirks[]` entry for any vendor-specific behavior the harness can't simulate. Tags must match `^[a-z0-9][a-z0-9-]*[a-z0-9]$` (loader-enforced):
+
+```yaml
+quirks:
+  - tag: boot-key-f12
+    description: "Firmware boot-menu key is F12. rescue-tui's MOK walkthrough STEP 3/3 covers this."
+  - tag: amd-ftpm-stuttering-pre-2024
+    description: "Pre-2024 AMD fTPM firmware had PCR-extend stuttering on rapid boots."
+```
+
+Quirk tags live in the persona's `quirks[]` so future scenarios can opt out of a persona by tag (e.g., a TPM-stress test could skip personas tagged `amd-ftpm-stuttering-pre-2024`).
+
+## Secure-Boot posture
+
+| `ovmf_variant` | Meaning | When to use |
+|---|---|---|
+| `ms_enrolled` | OVMF VARS pre-loaded with the Microsoft UEFI CA + KEKs | Default. Most shipping laptops boot under this. |
+| `custom_pk` | Persona ships a custom PK + KEK + db keyring | Tests the custom-CA enrollment path. Requires `secure_boot.custom_keyring` set to a path under `firmware/`. |
+| `setup_mode` | OVMF in setup mode — no PK enrolled | Tests the operator-MOK-enrollment flow. |
+| `disabled` | Secure Boot off | Tests the diagnostic path where aegis-boot refuses to flash. |
+
+The `custom_pk` keyring path is canonicalized + verified against the firmware-root sandbox at both load time AND at QEMU-invocation time (defense in depth) — see `src/loader.rs` and `src/qemu.rs`.
+
+## Test before shipping
+
+```bash
+# 1. Validate the YAML against the schema:
+cargo run --bin aegis-hwsim -- validate
+
+# 2. Confirm the loader accepts it:
+cargo test --locked --test loads_real_personas
+
+# 3. Confirm coverage-grid sees it:
+cargo run --bin aegis-hwsim -- coverage-grid --dry-run | grep <your-persona-id>
+```
+
+Then update `tests/loads_real_personas.rs` to assert the new id is in the loaded set.
+
+## PR checklist for a new persona
+
+- [ ] `personas/<id>.yaml` matches its filename stem
+- [ ] `source.kind` is the highest applicable confidence tier
+- [ ] If `kind: vendor_docs`, the YAML carries a PLACEHOLDER comment block
+- [ ] DMI fields are captured-as-shipped (no marketing-material guesses)
+- [ ] Quirks have grep-able tags + operator-actionable descriptions
+- [ ] `tests/loads_real_personas.rs` updated to assert the new id
+- [ ] `cargo test --locked` passes
+- [ ] CI green

--- a/docs/scenario-authoring.md
+++ b/docs/scenario-authoring.md
@@ -1,0 +1,172 @@
+# Authoring a new scenario
+
+A **scenario** is a Rust struct that takes a `ScenarioContext` (persona + stick + work_dir + firmware_root) and asserts a specific boot-flow invariant. Adding one extends the harness to cover a new failure mode.
+
+## The contract
+
+```rust
+pub trait Scenario {
+    fn name(&self) -> &'static str;          // kebab-case, stable forever once published
+    fn description(&self) -> &'static str;    // shown by `aegis-hwsim list-scenarios`
+    fn run(&self, ctx: &ScenarioContext) -> Result<ScenarioResult, ScenarioError>;
+}
+```
+
+Three invariants the trait enforces:
+
+1. **Never panic.** Every code path returns a Result. A scenario that crashes the runner is a defect.
+2. **Skip is first-class.** Returning `Ok(ScenarioResult::Skip { reason })` for missing prerequisites (no qemu, no stick, no swtpm) is the right choice — Skips don't pollute the matrix with FAIL/ERROR noise.
+3. **Runner errors are distinct from test failures.** `ScenarioError` (Err) means the runner couldn't get far enough to attempt the assertion — bad input, missing binary, I/O problem. `ScenarioResult::Fail { reason }` (Ok) means the assertion was attempted and didn't hold.
+
+## Where it lives
+
+`src/scenarios/<name>.rs`. Add a `pub mod <name>;` line + `pub use <name>::<Type>;` to `src/scenarios/mod.rs`. Register in `src/scenario.rs::Registry::default_set` and update the `registry_default_set_includes_shipped_scenarios` test count.
+
+## Two reference implementations
+
+Read these before writing a new scenario:
+
+- **`src/scenarios/qemu_boots_ovmf.rs`** — minimal, no-stick. Provisions a 1 MB empty file, spawns OVMF, asserts BdsDxe reaches serial. Self-contained; runs on CI without any signed artifact.
+- **`src/scenarios/signed_boot_ubuntu.rs`** — full pipeline. Walks 4 boot-chain landmarks (shim → grub → kernel → kexec) with per-landmark timeouts. Skips on missing stick / qemu / swtpm.
+
+## Standard skip gates
+
+Every scenario should check, in order:
+
+```rust
+// 1. Required binaries on PATH.
+if !binary_on_path("qemu-system-x86_64") {
+    return Ok(ScenarioResult::Skip {
+        reason: "qemu-system-x86_64 not on PATH (Debian: apt install qemu-system-x86)".into(),
+    });
+}
+
+// 2. Persona compatibility — Skip rather than Fail when the persona
+//    doesn't apply (e.g. a no-TPM scenario handed a TPM persona).
+if !matches!(ctx.persona.tpm.version, TpmVersion::None) {
+    return Ok(ScenarioResult::Skip {
+        reason: format!("scenario is no-TPM only; persona {} requests TPM", ctx.persona.id),
+    });
+}
+
+// 3. Stick prerequisites (if applicable).
+if !ctx.stick.is_file() {
+    return Ok(ScenarioResult::Skip {
+        reason: format!("stick {} not found", ctx.stick.display()),
+    });
+}
+```
+
+Skipping over Failing for a scenario-doesn't-apply case keeps the coverage-grid clean.
+
+## Composition pattern
+
+Use the existing modules — don't roll your own QEMU invocation:
+
+```rust
+use crate::qemu::Invocation;
+use crate::serial::SerialCapture;
+use crate::swtpm::{SwtpmInstance, SwtpmSpec};
+
+let swtpm_spec = SwtpmSpec::derive("scenario-name", &ctx.work_dir, ctx.persona.tpm.version);
+let swtpm = SwtpmInstance::spawn(&swtpm_spec)?;
+
+let inv = Invocation::new(
+    &ctx.persona,
+    &ctx.stick,
+    &ctx.work_dir,
+    &ctx.firmware_root,
+    &swtpm,
+)?;
+
+let log_path = ctx.work_dir.join("serial.log");
+let handle = SerialCapture::spawn(inv.build(), &log_path, None)?;
+
+if handle.wait_for_line("expected marker", Duration::from_secs(60)).is_some() {
+    Ok(ScenarioResult::Pass)
+} else {
+    Ok(ScenarioResult::Fail {
+        reason: format!("'expected marker' not seen within 60s. Serial log: {}.", log_path.display()),
+    })
+}
+```
+
+The `?` operator on `Invocation::new`, `SwtpmInstance::spawn`, and `SerialCapture::spawn` propagates runner errors via `ScenarioError` (the `#[from]` impls handle the conversion).
+
+## Registering
+
+`src/scenarios/mod.rs`:
+
+```rust
+pub mod my_new_scenario;
+pub use my_new_scenario::MyNewScenario;
+```
+
+`src/scenario.rs::Registry::default_set`:
+
+```rust
+pub fn default_set() -> Self {
+    let mut r = Self::empty();
+    r.register(Box::new(crate::scenarios::QemuBootsOvmf));
+    r.register(Box::new(crate::scenarios::SignedBootUbuntu));
+    r.register(Box::new(crate::scenarios::MyNewScenario));  // ← add here
+    r
+}
+```
+
+Update the test that pins the registry size:
+
+```rust
+fn registry_default_set_includes_shipped_scenarios() {
+    let r = Registry::default_set();
+    assert_eq!(r.len(), 3);  // ← bump
+    assert!(r.find("my-new-scenario").is_some());  // ← add
+    // ...
+}
+```
+
+## Tests inside the scenario file
+
+Mirror the reference scenarios:
+
+```rust
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    // ...
+    #[test]
+    fn name_and_description_are_stable() {
+        let s = MyNewScenario;
+        assert_eq!(s.name(), "my-new-scenario");
+        assert!(s.description().contains("relevant-keyword"));
+    }
+    #[test]
+    fn skips_when_<prerequisite>_missing() { /* ... */ }
+}
+```
+
+For scenarios that actually spawn QEMU (like `qemu-boots-ovmf`), also add a corresponding integration test under `tests/<name>_smoke.rs` that the CI workflow will exercise.
+
+## CI
+
+Once registered, your scenario shows up in:
+
+- `aegis-hwsim list-scenarios`
+- `aegis-hwsim coverage-grid` (tested against every persona)
+- The CI `coverage-grid` artifact published per PR
+
+If your scenario can run end-to-end on Ubuntu CI without a signed stick (like `qemu-boots-ovmf`), add a corresponding `tests/<name>_smoke.rs` integration test — it'll automatically run as part of `cargo test --locked` in CI.
+
+## PR checklist
+
+- [ ] Scenario in `src/scenarios/<name>.rs` with stable `name()`
+- [ ] Re-exported from `src/scenarios/mod.rs`
+- [ ] Registered in `Registry::default_set`
+- [ ] `registry_default_set_includes_shipped_scenarios` test updated
+- [ ] Standard skip gates for missing binaries / prerequisites
+- [ ] `name_and_description_are_stable` test
+- [ ] Skip-path test for at least one prerequisite
+- [ ] If runnable without a signed stick, integration test under `tests/<name>_smoke.rs`
+- [ ] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test --locked` all pass
+- [ ] CI green; check the coverage-grid artifact for sane cells

--- a/src/bin/aegis-hwsim.rs
+++ b/src/bin/aegis-hwsim.rs
@@ -18,6 +18,7 @@ fn main() -> ExitCode {
         Some("run") => run_scenario(&args[1..]),
         Some("list-scenarios") => run_list_scenarios(&args[1..]),
         Some("coverage-grid") => run_coverage_grid(&args[1..]),
+        Some("doctor") => run_doctor(&args[1..]),
         Some("-h" | "--help" | "help") | None => {
             print_help();
             ExitCode::SUCCESS
@@ -46,6 +47,8 @@ fn print_help() {
     println!("                                      Run a scenario against a persona+stick");
     println!("  aegis-hwsim coverage-grid [--format json|markdown] [--dry-run]");
     println!("                                      Emit persona × scenario grid");
+    println!("  aegis-hwsim doctor [--firmware-root DIR]");
+    println!("                                      Check host has qemu/swtpm/ovmf installed");
     println!("  aegis-hwsim --version               Print version");
     println!("  aegis-hwsim --help                  This message");
     println!();
@@ -275,6 +278,33 @@ fn run_gen_schema(args: &[String]) -> ExitCode {
         }
     } else {
         print!("{rendered}");
+        ExitCode::SUCCESS
+    }
+}
+
+/// `aegis-hwsim doctor` — host environment check. Returns exit 0 on
+/// PASS or WARN, 1 on FAIL. Operators run this before filing a bug
+/// report so they (and we) know the host has every prerequisite.
+fn run_doctor(args: &[String]) -> ExitCode {
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+        println!("aegis-hwsim doctor — check host has qemu/swtpm/ovmf installed");
+        println!();
+        println!("USAGE:");
+        println!("  aegis-hwsim doctor [--firmware-root DIR]");
+        println!();
+        println!("  --firmware-root DIR  Override OVMF dir (default: /usr/share/OVMF)");
+        return ExitCode::SUCCESS;
+    }
+    let firmware_root = args
+        .iter()
+        .position(|a| a == "--firmware-root")
+        .and_then(|i| args.get(i + 1))
+        .map_or_else(|| PathBuf::from("/usr/share/OVMF"), PathBuf::from);
+    let report = aegis_hwsim::doctor::run(&firmware_root);
+    print!("{}", report.render());
+    if report.has_failures() {
+        ExitCode::from(1)
+    } else {
         ExitCode::SUCCESS
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,390 @@
+//! Host-environment check.
+//!
+//! `aegis-hwsim doctor` inspects the host for the binaries + firmware
+//! files the harness needs (qemu-system-x86_64, swtpm, OVMF
+//! {CODE,VARS}_4M.{secboot.,}.{ms.,}fd) and reports per-check
+//! verdicts (`OK` / `WARN` / `FAIL`). Mirrors the
+//! [aegis-boot doctor](https://github.com/williamzujkowski/aegis-boot)
+//! shape so operators get the same diagnostic UX across the family.
+//!
+//! Pure logic + path/PATH lookups; no subprocess spawning beyond
+//! version probes (and even those use `--version`/`-v`, never shells).
+//!
+//! Why an aegis-hwsim doctor: when a scenario `Skip`s with reason
+//! "qemu-system-x86_64 not on PATH", the operator gets ONE skip
+//! reason at a time. Doctor surfaces them all in one pass so the
+//! operator can fix everything in one apt-install.
+
+use std::path::{Path, PathBuf};
+
+/// Per-check outcome. Mirrors aegis-boot's `Verdict` for cross-family
+/// readability — operators familiar with `aegis-boot doctor` see the
+/// same labels here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Check passed; no action needed.
+    Pass,
+    /// Check found a degraded-but-usable state (e.g. swtpm missing,
+    /// only no-TPM scenarios will run).
+    Warn,
+    /// Check failed; the harness can't run at all without the
+    /// referenced fix.
+    Fail,
+}
+
+impl Verdict {
+    /// Single-character status for the table prefix.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Pass => "PASS",
+            Self::Warn => "WARN",
+            Self::Fail => "FAIL",
+        }
+    }
+}
+
+/// One row of the doctor report.
+#[derive(Debug, Clone)]
+pub struct Check {
+    /// Verdict.
+    pub verdict: Verdict,
+    /// Subject of the check (e.g. `qemu-system-x86_64`).
+    pub subject: String,
+    /// One-line operator-facing message. For `Pass`, what was found;
+    /// for `Warn`/`Fail`, the action to take.
+    pub message: String,
+}
+
+/// Output of [`run`]. Aggregates per-check rows + a single
+/// [`Self::next_action`] pointer.
+#[derive(Debug, Clone)]
+pub struct Report {
+    /// Ordered checks.
+    pub checks: Vec<Check>,
+}
+
+impl Report {
+    /// Whether any check has FAIL severity.
+    #[must_use]
+    pub fn has_failures(&self) -> bool {
+        self.checks.iter().any(|c| c.verdict == Verdict::Fail)
+    }
+
+    /// Whether any check has WARN severity.
+    #[must_use]
+    pub fn has_warnings(&self) -> bool {
+        self.checks.iter().any(|c| c.verdict == Verdict::Warn)
+    }
+
+    /// Single operator-facing next-action string. Picks the
+    /// highest-severity actionable check; falls back to a celebratory
+    /// "ready" message when everything passes.
+    #[must_use]
+    pub fn next_action(&self) -> String {
+        if let Some(c) = self.checks.iter().find(|c| c.verdict == Verdict::Fail) {
+            return format!("FIX: {} — {}", c.subject, c.message);
+        }
+        if let Some(c) = self.checks.iter().find(|c| c.verdict == Verdict::Warn) {
+            return format!("CONSIDER: {} — {}", c.subject, c.message);
+        }
+        "ALL CHECKS PASS — harness is ready for any registered scenario".to_string()
+    }
+
+    /// Pretty-print the report to a String. Operator-facing format
+    /// matches the aegis-boot family; columns: VERDICT, SUBJECT,
+    /// MESSAGE.
+    #[must_use]
+    pub fn render(&self) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::with_capacity(self.checks.len() * 80);
+        let _ = writeln!(out, "{:<6} {:<30} MESSAGE", "STATUS", "SUBJECT");
+        for c in &self.checks {
+            let _ = writeln!(
+                out,
+                "{:<6} {:<30} {}",
+                c.verdict.label(),
+                c.subject,
+                c.message
+            );
+        }
+        let _ = writeln!(out);
+        let _ = writeln!(out, "NEXT ACTION: {}", self.next_action());
+        out
+    }
+}
+
+/// Run the doctor checks against `firmware_root`. Returns a [`Report`]
+/// the caller renders + uses to set its exit code (FAIL → 1, WARN →
+/// 0, ALL PASS → 0).
+#[must_use]
+pub fn run(firmware_root: &Path) -> Report {
+    let mut checks = Vec::with_capacity(8);
+
+    // Required binaries.
+    checks.push(check_binary(
+        "qemu-system-x86_64",
+        Verdict::Fail,
+        "Debian: apt install qemu-system-x86. Required for every scenario.",
+    ));
+    checks.push(check_binary(
+        "swtpm",
+        Verdict::Warn,
+        "Debian: apt install swtpm. Only no-TPM scenarios (qemu-boots-ovmf) \
+         can run without it; persona-driven TPM scenarios will Skip.",
+    ));
+
+    // OVMF firmware files.
+    checks.push(check_firmware_file(
+        firmware_root,
+        "OVMF_CODE_4M.secboot.fd",
+        Verdict::Fail,
+        "Debian: apt install ovmf. Required for any Secure-Boot scenario.",
+    ));
+    checks.push(check_firmware_file(
+        firmware_root,
+        "OVMF_VARS_4M.ms.fd",
+        Verdict::Fail,
+        "Debian: apt install ovmf (provides the MS-enrolled VARS template).",
+    ));
+    checks.push(check_firmware_file(
+        firmware_root,
+        "OVMF_CODE_4M.fd",
+        Verdict::Warn,
+        "Optional: needed only by personas with ovmf_variant=disabled.",
+    ));
+    checks.push(check_firmware_file(
+        firmware_root,
+        "OVMF_VARS_4M.fd",
+        Verdict::Warn,
+        "Optional: needed by personas with ovmf_variant=setup_mode or =disabled.",
+    ));
+
+    // Persona library presence.
+    checks.push(check_personas_dir(Path::new("personas")));
+
+    Report { checks }
+}
+
+fn check_binary(name: &str, severity_on_miss: Verdict, fix: &str) -> Check {
+    if let Some(path) = which_on_path(name) {
+        Check {
+            verdict: Verdict::Pass,
+            subject: name.to_string(),
+            message: format!("found at {}", path.display()),
+        }
+    } else {
+        Check {
+            verdict: severity_on_miss,
+            subject: name.to_string(),
+            message: format!("not on PATH. {fix}"),
+        }
+    }
+}
+
+fn check_firmware_file(root: &Path, filename: &str, severity_on_miss: Verdict, fix: &str) -> Check {
+    let path = root.join(filename);
+    if path.is_file() {
+        Check {
+            verdict: Verdict::Pass,
+            subject: filename.to_string(),
+            message: format!("found at {}", path.display()),
+        }
+    } else {
+        Check {
+            verdict: severity_on_miss,
+            subject: filename.to_string(),
+            message: format!("missing under {}. {fix}", root.display()),
+        }
+    }
+}
+
+fn check_personas_dir(personas_dir: &Path) -> Check {
+    if !personas_dir.is_dir() {
+        return Check {
+            verdict: Verdict::Fail,
+            subject: "personas/".into(),
+            message: format!(
+                "directory not found at {}. Run from the aegis-hwsim repo root.",
+                personas_dir.display()
+            ),
+        };
+    }
+    let count = std::fs::read_dir(personas_dir)
+        .map(|iter| {
+            iter.flatten()
+                .filter(|e| {
+                    e.path()
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .is_some_and(|s| s == "yaml")
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    if count == 0 {
+        return Check {
+            verdict: Verdict::Fail,
+            subject: "personas/".into(),
+            message: format!(
+                "no .yaml files under {}. Persona library is empty.",
+                personas_dir.display()
+            ),
+        };
+    }
+    Check {
+        verdict: Verdict::Pass,
+        subject: "personas/".into(),
+        message: format!("{count} persona file(s) present"),
+    }
+}
+
+/// PATH lookup matching the scenarios' `binary_on_path` helper,
+/// returning the resolved path (not just bool) so we can include it
+/// in the Pass message.
+fn which_on_path(binary: &str) -> Option<PathBuf> {
+    let path = std::env::var("PATH").ok()?;
+    for dir in path.split(':') {
+        let candidate = PathBuf::from(dir).join(binary);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn fake_firmware_root() -> (TempDir, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        for name in [
+            "OVMF_CODE_4M.secboot.fd",
+            "OVMF_CODE_4M.fd",
+            "OVMF_VARS_4M.ms.fd",
+            "OVMF_VARS_4M.fd",
+        ] {
+            std::fs::write(root.join(name), b"fake").unwrap();
+        }
+        (tmp, root)
+    }
+
+    #[test]
+    fn next_action_picks_first_failure() {
+        let r = Report {
+            checks: vec![
+                Check {
+                    verdict: Verdict::Pass,
+                    subject: "a".into(),
+                    message: "ok".into(),
+                },
+                Check {
+                    verdict: Verdict::Fail,
+                    subject: "missing-binary".into(),
+                    message: "install via apt".into(),
+                },
+                Check {
+                    verdict: Verdict::Warn,
+                    subject: "should-not-be-picked".into(),
+                    message: "warn".into(),
+                },
+            ],
+        };
+        assert!(r.has_failures());
+        assert!(r.next_action().contains("missing-binary"));
+        assert!(r.next_action().starts_with("FIX:"));
+    }
+
+    #[test]
+    fn next_action_picks_warning_when_no_failures() {
+        let r = Report {
+            checks: vec![
+                Check {
+                    verdict: Verdict::Pass,
+                    subject: "a".into(),
+                    message: "ok".into(),
+                },
+                Check {
+                    verdict: Verdict::Warn,
+                    subject: "swtpm".into(),
+                    message: "install for TPM scenarios".into(),
+                },
+            ],
+        };
+        assert!(!r.has_failures());
+        assert!(r.has_warnings());
+        let action = r.next_action();
+        assert!(action.starts_with("CONSIDER:"));
+        assert!(action.contains("swtpm"));
+    }
+
+    #[test]
+    fn next_action_celebrates_when_all_pass() {
+        let r = Report {
+            checks: vec![Check {
+                verdict: Verdict::Pass,
+                subject: "everything".into(),
+                message: "ok".into(),
+            }],
+        };
+        assert!(!r.has_failures());
+        assert!(!r.has_warnings());
+        assert!(r.next_action().starts_with("ALL CHECKS PASS"));
+    }
+
+    #[test]
+    fn check_firmware_file_returns_pass_when_present() {
+        let (_tmp, root) = fake_firmware_root();
+        let c = check_firmware_file(
+            &root,
+            "OVMF_CODE_4M.secboot.fd",
+            Verdict::Fail,
+            "install ovmf",
+        );
+        assert_eq!(c.verdict, Verdict::Pass);
+        assert!(c.message.contains("found at"));
+    }
+
+    #[test]
+    fn check_firmware_file_returns_severity_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let c = check_firmware_file(tmp.path(), "OVMF_CODE_4M.secboot.fd", Verdict::Fail, "fix");
+        assert_eq!(c.verdict, Verdict::Fail);
+        assert!(c.message.contains("missing"));
+    }
+
+    #[test]
+    fn check_binary_returns_pass_for_sh() {
+        // /bin/sh is on PATH on every CI runner.
+        let c = check_binary("sh", Verdict::Fail, "fix");
+        assert_eq!(c.verdict, Verdict::Pass);
+    }
+
+    #[test]
+    fn check_binary_returns_severity_for_missing() {
+        let c = check_binary("definitely-not-a-binary-xyz-doctor", Verdict::Warn, "fix");
+        assert_eq!(c.verdict, Verdict::Warn);
+        assert!(c.message.contains("not on PATH"));
+    }
+
+    #[test]
+    fn check_personas_dir_returns_fail_for_missing_dir() {
+        let c = check_personas_dir(Path::new("/no/such/personas-dir-xyz"));
+        assert_eq!(c.verdict, Verdict::Fail);
+    }
+
+    #[test]
+    fn render_includes_status_subject_message_and_next_action() {
+        let (_tmp, root) = fake_firmware_root();
+        let r = run(&root);
+        let s = r.render();
+        assert!(s.contains("STATUS"));
+        assert!(s.contains("SUBJECT"));
+        assert!(s.contains("MESSAGE"));
+        assert!(s.contains("NEXT ACTION:"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![warn(missing_docs)]
 
 pub mod coverage_grid;
+pub mod doctor;
 pub mod loader;
 pub mod ovmf;
 pub mod persona;


### PR DESCRIPTION
## Summary

aegis-hwsim doctor inspects the host for every binary + firmware file the harness needs and reports per-check verdicts (PASS/WARN/FAIL) plus a NEXT ACTION pointer. Mirrors aegis-boot doctor's shape so operators get the same diagnostic UX across the family.

Three contributor docs (CONTRIBUTING.md, persona-authoring, scenario-authoring) ship alongside so the next contributor doesn't have to reverse-engineer the conventions from existing PRs.

## Doctor sample output

```
$ aegis-hwsim doctor
STATUS SUBJECT                        MESSAGE
PASS   qemu-system-x86_64             found at /usr/bin/qemu-system-x86_64
PASS   swtpm                          found at /usr/bin/swtpm
PASS   OVMF_CODE_4M.secboot.fd        found at /usr/share/OVMF/OVMF_CODE_4M.secboot.fd
PASS   OVMF_VARS_4M.ms.fd             found at /usr/share/OVMF/OVMF_VARS_4M.ms.fd
PASS   OVMF_CODE_4M.fd                found at /usr/share/OVMF/OVMF_CODE_4M.fd
PASS   OVMF_VARS_4M.fd                found at /usr/share/OVMF/OVMF_VARS_4M.fd
PASS   personas/                      7 persona file(s) present

NEXT ACTION: ALL CHECKS PASS — harness is ready for any registered scenario
```

Exits 1 on any FAIL, 0 on WARN or all-PASS.

## Why

When scenarios Skip with "qemu-system-x86_64 not on PATH", the operator sees ONE skip reason at a time and fixes them iteratively. doctor surfaces them all at once → fewer apt-install round-trips.

## Contributor docs

- **CONTRIBUTING.md** — quickstart (with `doctor` first), what we accept/don't, source-citation policy, lint policy, PR flow, co-author footer.
- **docs/persona-authoring.md** — schema reference, vendor DMI conventions (preserve trailing periods!), source-citation tiers (community_report → lvfs_catalog → vendor_docs PLACEHOLDER), quirk-tag regex, PR checklist.
- **docs/scenario-authoring.md** — Scenario trait contract, three invariants (no panic / Skip first-class / runner errors distinct from test failures), composition pattern using the existing qemu/serial/swtpm modules, registration steps, PR checklist.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --locked` (105 tests, includes 9 new doctor)
- [x] `aegis-hwsim doctor` locally reports 'ALL CHECKS PASS' against /usr/share/OVMF
- [ ] CI green