### PR TITLE
docs+persona: CHANGELOG.md + ThinkPad T440p TPM 1.2 persona

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to aegis-hwsim. Mirrors the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) convention; the project follows [aegis-boot](https://github.com/williamzujkowski/aegis-boot)'s release cadence.
+
+## [Unreleased]
+
+### Added
+
+- Phase 1 + Phase 2 in one cohesive push:
+  - **Persona library** (E1): YAML schema with `serde` derives, `load_all()` with 5 guards (placeholder rejection, id/filename drift, quirk-tag regex, custom-keyring path-boundary, parse). 7 personas shipped — qemu-generic-minimal, lenovo-thinkpad-x1-carbon-gen11, framework-laptop-12gen, dell-xps-13-9320, hp-elitebook-845-g10, asus-zenbook-14-oled, qemu-smoke-no-tpm.
+  - **JSONSchema export** (E1.5): `aegis-hwsim gen-schema [--check PATH]` emits `schemas/persona.schema.json`. CI drift gate prevents source/schema skew.
+  - **QEMU synthesis layer** (E2, all 7 children): smbios::smbios_argv for `-smbios type=0/1/2/3` argv with QEMU comma-escape + NUL rejection; ovmf::resolve for OVMF_CODE/VARS firmware paths (Debian + Fedora layouts, custom_keyring path-boundary); swtpm::SwtpmInstance with per-run socket + drop-guard cleanup; qemu::Invocation builder composing everything into a `Command`; serial::SerialCapture with `wait_for_line` + bounded-buffer overflow handling; subprocess-safety fuzz (60k random inputs / commit covering shell metacharacters + UTF-8 RTL + NUL); per-run OVMF_VARS path-boundary defense.
+  - **Scenario runner** (E3.1-E3.3): `Scenario` trait + `ScenarioResult` (Pass/Fail/Skip) + `Registry`; `signed-boot-ubuntu` scenario walking shim → grub → kernel → kexec landmarks; `aegis-hwsim run <persona> <scenario> <stick.img>` CLI subcommand + `aegis-hwsim list-scenarios`.
+  - **`qemu-boots-ovmf` smoke scenario**: boots OVMF over an empty 1 MB stick, asserts BdsDxe boot-selector reaches serial. Runs end-to-end on CI without a signed stick artifact (1.69s local) — proves the harness pipeline every PR.
+  - **Coverage-grid emitter** (E4.1): `aegis-hwsim coverage-grid [--format json|markdown] [--dry-run]` iterates personas × scenarios. CI publishes the result as a build artifact every PR with 30-day retention.
+  - **`aegis-hwsim doctor`**: host-environment check mirroring aegis-boot doctor — reports per-check verdicts (PASS/WARN/FAIL) for qemu-system-x86_64, swtpm, OVMF firmware files, persona library presence. Surfaces all missing prereqs in one pass.
+  - **Contributor docs**: CONTRIBUTING.md, docs/persona-authoring.md, docs/scenario-authoring.md.
+
+### Security
+
+- `unsafe_code = "forbid"` workspace-wide.
+- `unwrap_used = "deny"` and `expect_used = "deny"` in production code; tests opt back out at the `#[cfg(test)] mod tests` boundary.
+- All CLI subcommands shell out via `Command::args()` (no `sh -c`); persona DMI strings pass through as literal argv.
+- NUL-byte rejection at every subprocess boundary (smbios, qemu::Invocation).
+- Path-boundary defense: `custom_keyring` (`ovmf::resolve`) and per-run OVMF_VARS copy (`qemu::Invocation`) both canonicalized + verified `starts_with(root)` after the operation, defending against symlink swap-in attacks.
+- HTTPS-only enforcement on any URL inputs (none in aegis-hwsim today, but contract noted for future scenarios).
+
+### CI
+
+- Lint + test on every PR under `-D warnings`.
+- JSONSchema drift gate.
+- `qemu-boots-ovmf` smoke runs against real QEMU+OVMF on Ubuntu runner.
+- `coverage-grid` artifact (markdown + JSON) uploaded per PR.
+
+### Deferred to future releases
+
+- `mok-enroll-alpine` scenario — requires real-hardware MOK Manager UI flow.
+- `attestation-roundtrip` scenario — blocked on aegis-boot manifest format pin.
+- End-to-end `signed-boot-ubuntu` against a real signed aegis-boot stick — the scenario code is shipped; needs a stick artifact in CI.
+- Phase 3 v1.0.0-rc1 release gate.

--- a/personas/lenovo-thinkpad-t440p-tpm12.yaml
+++ b/personas/lenovo-thinkpad-t440p-tpm12.yaml
@@ -1,0 +1,57 @@
+schema_version: 1
+id: lenovo-thinkpad-t440p-tpm12
+vendor: LENOVO
+display_name: "Lenovo ThinkPad T440p (Haswell, TPM 1.2)"
+year: 2014
+
+source:
+  # Placeholder citation. Do NOT ship to main until a real operator
+  # files a hardware-report on aegis-boot covering the full flash → boot
+  # → kexec chain on a physical T440p with TPM 1.2 enabled. See
+  # aegis-boot CLAUDE.md and HARDWARE_COMPAT.md "verified outcomes only"
+  # policy.
+  #
+  # Why this persona: every other persona in the library uses TPM 2.0.
+  # The ThinkPad T440p era (2014-2015) shipped with discrete TPM 1.2
+  # parts (ST33 / Atmel) and is still in active service for low-budget
+  # rescue-stick operators. Without a 1.2 persona, the qemu::Invocation
+  # builder's tpm-tis device path is exercised only by unit tests, not
+  # by the matrix.
+  kind: vendor_docs
+  ref_: "Lenovo PSREF ThinkPad T440p Type 20AN/20AQ (placeholder — replace with community_report URL before main)"
+
+dmi:
+  sys_vendor: LENOVO
+  product_name: 20AN0069US
+  product_version: "ThinkPad T440p"
+  bios_vendor: LENOVO
+  # T440p firmware family: GLET; final-shipped 2.43 cited in many
+  # community reports, but operators with newer "modded" / Coreboot
+  # alternatives also exist.
+  bios_version: "GLET98WW (2.43)"
+  bios_date: 06/15/2017
+  board_name: 20AN0069US
+  chassis_type: 10   # SMBIOS "Notebook"
+
+secure_boot:
+  ovmf_variant: ms_enrolled
+
+tpm:
+  # Discrete TPM 1.2 (ST33 — most common shipped option; Atmel was an
+  # alternate). qemu::Invocation routes this through `tpm-tis` (TIS
+  # interface) rather than `tpm-crb` (CRB, 2.0-only).
+  version: "1.2"
+  manufacturer: STM     # STMicroelectronics ST33 family
+
+kernel:
+  lockdown: inherit
+
+quirks:
+  - tag: tpm-tis-not-crb
+    description: "TPM 1.2 uses the TIS interface (ISA-style, address 0xFED40000). qemu-system-x86_64 device is `tpm-tis`, not `tpm-crb`. swtpm needs to be invoked WITHOUT `--tpm2`."
+  - tag: boot-key-f12
+    description: "Firmware boot-menu key is F12 — Lenovo convention since the original ThinkPad. rescue-tui MOK walkthrough STEP 3/3 covers this."
+  - tag: tpm-1-2-attestation-narrow
+    description: "TPM 1.2 PCR bank is SHA-1 only (no SHA-256/SHA-384 like 2.0). Any attestation-roundtrip scenario must select the SHA-1 bank explicitly when comparing PCR extends."
+  - tag: secure-boot-default-on
+    description: "T440p ships with Secure Boot enabled by default since the original Win8 SKU. Compatible with ms_enrolled."

--- a/tests/loads_real_personas.rs
+++ b/tests/loads_real_personas.rs
@@ -14,8 +14,8 @@ fn shipped_personas_load_without_error() {
     let opts = LoadOptions::default_at(&repo_root);
     let personas = load_all(&opts).unwrap_or_else(|e| panic!("load_all failed: {e}"));
     assert!(
-        personas.len() >= 7,
-        "expected ≥7 personas after Phase 2 + smoke persona, got {}",
+        personas.len() >= 8,
+        "expected ≥8 personas after Phase 2 + smoke + TPM 1.2 personas, got {}",
         personas.len()
     );
     let ids: std::collections::HashSet<_> = personas.iter().map(|p| p.id.as_str()).collect();
@@ -27,4 +27,8 @@ fn shipped_personas_load_without_error() {
     assert!(ids.contains("dell-xps-13-9320"));
     assert!(ids.contains("hp-elitebook-845-g10"));
     assert!(ids.contains("asus-zenbook-14-oled"));
+    // Harness self-test (no TPM).
+    assert!(ids.contains("qemu-smoke-no-tpm"));
+    // TPM 1.2 coverage — exercises the qemu::Invocation tpm-tis path.
+    assert!(ids.contains("lenovo-thinkpad-t440p-tpm12"));
 }


### PR DESCRIPTION
Two small additions:

1. **CHANGELOG.md** — Keep-a-Changelog format, captures Phase 1 + Phase 2 work under [Unreleased]. Includes a 'Deferred to future releases' section so contributors know what's parked vs missing.

2. **`lenovo-thinkpad-t440p-tpm12` persona** — first TPM 1.2 entry. Every other persona uses TPM 2.0; T440p exercises qemu::Invocation's tpm-tis device path (vs the tpm-crb path that 2.0 personas use). Persona library now 8 entries.

Quirks captured for the T440p: tpm-tis-not-crb, tpm-1-2-attestation-narrow (SHA-1-only PCR bank), boot-key-f12.

## Test plan

- [x] cargo test --locked — 105 tests, includes updated loads_real_personas asserting ≥8 + the new id
- [x] aegis-hwsim list-personas shows 8 entries with TPM 1.2 column for T440p
- [ ] CI green