### PR TITLE
feat(persona): qemu-disabled-sb — covers OvmfVariant::Disabled branch

### DIFF
--- a/personas/qemu-disabled-sb.yaml
+++ b/personas/qemu-disabled-sb.yaml
@@ -1,0 +1,41 @@
+schema_version: 1
+id: qemu-disabled-sb
+vendor: QEMU
+display_name: "QEMU diagnostic (Secure Boot disabled)"
+year: 2024
+
+source:
+  # Harness-only persona for the SB-disabled diagnostic path.
+  # aegis-boot's contract: when Secure Boot is disabled, the operator
+  # gets a SignatureRejected-equivalent refusal to flash. This persona
+  # exercises the only remaining ovmf_variant branch (Disabled, which
+  # uses non-secboot CODE + blank VARS) — every other persona uses
+  # MS-enrolled. Without it, the qemu::Invocation Disabled path is
+  # exercised only by unit tests, not by the matrix.
+  kind: vendor_docs
+  ref_: "QEMU -smbios documentation + OVMF non-secboot reference"
+
+dmi:
+  sys_vendor: QEMU
+  product_name: "Standard PC (Q35 + ICH9, 2009)"
+  bios_vendor: EDK II
+  bios_version: "edk2-stable202402"
+  bios_date: 02/29/2024
+
+secure_boot:
+  ovmf_variant: disabled
+
+tpm:
+  # SB-disabled diagnostic doesn't need TPM. Keeps the persona
+  # lightweight and avoids requiring swtpm in CI for matrix coverage
+  # of this branch.
+  version: none
+
+kernel:
+  lockdown: inherit
+
+quirks:
+  - tag: harness-self-test-only
+    description: "Diagnostic persona for the SB-disabled boot path. Not a real laptop."
+  - tag: secure-boot-off-aegis-refuses
+    description: "aegis-boot's contract is to REFUSE to flash when SB is disabled (rather than silently downgrade trust). Any scenario covering this persona should assert that refusal, not boot success."

--- a/tests/loads_real_personas.rs
+++ b/tests/loads_real_personas.rs
@@ -14,8 +14,8 @@ fn shipped_personas_load_without_error() {
     let opts = LoadOptions::default_at(&repo_root);
     let personas = load_all(&opts).unwrap_or_else(|e| panic!("load_all failed: {e}"));
     assert!(
-        personas.len() >= 8,
-        "expected ≥8 personas after Phase 2 + smoke + TPM 1.2 personas, got {}",
+        personas.len() >= 9,
+        "expected ≥9 personas (Phase 2 + smoke + TPM 1.2 + disabled-SB), got {}",
         personas.len()
     );
     let ids: std::collections::HashSet<_> = personas.iter().map(|p| p.id.as_str()).collect();
@@ -31,4 +31,7 @@ fn shipped_personas_load_without_error() {
     assert!(ids.contains("qemu-smoke-no-tpm"));
     // TPM 1.2 coverage — exercises the qemu::Invocation tpm-tis path.
     assert!(ids.contains("lenovo-thinkpad-t440p-tpm12"));
+    // Disabled-SB diagnostic — exercises the only remaining
+    // OvmfVariant branch (Disabled, non-secboot CODE).
+    assert!(ids.contains("qemu-disabled-sb"));
 }


### PR DESCRIPTION
Plugs the last gap in OVMF variant coverage. Every other persona uses ms_enrolled; this one (no-TPM by design) exercises the Disabled branch (non-secboot CODE + blank VARS) that previously only ovmf::resolve unit tests covered.

Quirks documented include the aegis-boot contract that SB-off should produce a refusal, not a silent trust-downgrade — relevant for any future scenario that targets this persona.

Library is now 9 entries; OVMF variant matrix is complete (ms_enrolled × 8, disabled × 1; custom_pk + setup_mode still future work pending a test keyring).

## Test plan

- [x] cargo test --locked (passes; loads_real_personas asserts ≥9)
- [x] aegis-hwsim list-personas shows 9 entries with the disabled OVMF + none TPM column for the new row
- [ ] CI green