### PR TITLE
feat(persona): qemu-setup-mode-sb — covers OvmfVariant::SetupMode

### DIFF
--- a/personas/qemu-setup-mode-sb.yaml
+++ b/personas/qemu-setup-mode-sb.yaml
@@ -1,0 +1,46 @@
+schema_version: 1
+id: qemu-setup-mode-sb
+vendor: QEMU
+display_name: "QEMU diagnostic (Secure Boot in Setup Mode — operator MOK enrollment flow)"
+year: 2024
+
+source:
+  # Harness-only persona for the SB Setup Mode boot path. Setup Mode
+  # is what new motherboards ship in BEFORE the OEM enrolls the PK —
+  # OVMF's behavior here matches an operator who's reset their
+  # SB variables (a real-world recovery flow). aegis-boot's MOK
+  # enrollment walkthrough (#202) targets this state.
+  #
+  # Without this persona, ovmf::resolve's SetupMode branch (secboot
+  # CODE + blank VARS) is exercised only by unit tests, never by the
+  # matrix.
+  kind: vendor_docs
+  ref_: "QEMU -smbios documentation + OVMF Setup Mode (OVMF_VARS_4M.fd, blank/no-PK)"
+
+dmi:
+  sys_vendor: QEMU
+  product_name: "Standard PC (Q35 + ICH9, 2009)"
+  bios_vendor: EDK II
+  bios_version: "edk2-stable202402"
+  bios_date: 02/29/2024
+
+secure_boot:
+  ovmf_variant: setup_mode
+
+tpm:
+  # Setup Mode is about SB key state, not TPM. Keep this no-TPM
+  # so it stays harness-self-test-eligible without expanding swtpm
+  # dependencies. Real-hardware MOK-enrollment scenarios will use
+  # a TPM-bearing persona separately.
+  version: none
+
+kernel:
+  lockdown: inherit
+
+quirks:
+  - tag: harness-self-test-only
+    description: "Diagnostic persona for the SB-setup-mode boot path. Not a real laptop."
+  - tag: setup-mode-no-pk
+    description: "Setup Mode means no PK enrolled — OVMF accepts unsigned binaries until the operator enrolls PK + KEK + db. Real flow: operator reboots into MokManager, enrolls a hash or a key, returns to OVMF which now refuses unsigned. aegis-boot#202 covers the operator-side walkthrough."
+  - tag: ovmf-vars-blank
+    description: "Setup Mode uses the blank VARS template (OVMF_VARS_4M.fd, not the .ms.fd MS-enrolled variant). Matrix coverage of this branch was previously gated on this persona."

--- a/tests/loads_real_personas.rs
+++ b/tests/loads_real_personas.rs
@@ -14,8 +14,8 @@ fn shipped_personas_load_without_error() {
     let opts = LoadOptions::default_at(&repo_root);
     let personas = load_all(&opts).unwrap_or_else(|e| panic!("load_all failed: {e}"));
     assert!(
-        personas.len() >= 9,
-        "expected ≥9 personas (Phase 2 + smoke + TPM 1.2 + disabled-SB), got {}",
+        personas.len() >= 10,
+        "expected ≥10 personas (Phase 2 + smoke + TPM 1.2 + disabled-SB + setup-mode), got {}",
         personas.len()
     );
     let ids: std::collections::HashSet<_> = personas.iter().map(|p| p.id.as_str()).collect();
@@ -31,7 +31,12 @@ fn shipped_personas_load_without_error() {
     assert!(ids.contains("qemu-smoke-no-tpm"));
     // TPM 1.2 coverage — exercises the qemu::Invocation tpm-tis path.
     assert!(ids.contains("lenovo-thinkpad-t440p-tpm12"));
-    // Disabled-SB diagnostic — exercises the only remaining
-    // OvmfVariant branch (Disabled, non-secboot CODE).
+    // Disabled-SB diagnostic — exercises the Disabled OvmfVariant
+    // branch (non-secboot CODE).
     assert!(ids.contains("qemu-disabled-sb"));
+    // Setup-mode diagnostic — exercises the SetupMode branch
+    // (secboot CODE + blank VARS, no PK enrolled). Together with
+    // qemu-disabled-sb + the 8 ms_enrolled personas, the matrix now
+    // hits 3/4 OvmfVariants. Custom-PK still requires a test keyring.
+    assert!(ids.contains("qemu-setup-mode-sb"));
 }


### PR DESCRIPTION
Third of four OVMF variants in the matrix. Setup Mode = OVMF with secboot CODE + blank VARS (no PK) — the state new motherboards ship in BEFORE OEM enrollment, and what an operator returns to after resetting SB variables. aegis-boot#202's MOK walkthrough targets exactly this state.

Persona is no-TPM by design (Setup Mode is about SB keys, not TPM) so stays harness-self-test-eligible.

Library now 10 entries; OVMF coverage: ms_enrolled (8) + disabled (1) + setup_mode (1) + custom_pk (still future — needs test keyring + relative-path resolution decision).

## Test plan

- [x] cargo test --locked
- [x] aegis-hwsim list-personas shows the new entry with setup-mode + none columns
- [ ] CI green