### PR TITLE
docs+refactor: research index refresh + binary_on_path dedup

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -7,6 +7,8 @@ Nexus-agents-style research tracking for aegis-hwsim. Every external claim in ou
 | File | Purpose |
 |------|---------|
 | [prior-art.md](prior-art.md) | Tool-by-tool survey of adjacent projects (chipsec, fwts, LAVA, openQA, fwupd CI, ...). Why each is / isn't overlap. |
+| [recent-projects.md](recent-projects.md) | 2025/2026 delta-scan: new projects, evolved tooling, and explicit non-findings. Tracks what's *moved* since the initial prior-art pass. |
+| [arxiv-papers.md](arxiv-papers.md) | Verified academic papers (arxiv ID or DOI) tied to aegis-hwsim's scope: SoK on UEFI security, boot integrity surveys, vTPM attestation, UEFI memory forensics, EDK-2 fuzzing harness design. |
 | [gotchas.md](gotchas.md) | Confirmed limitations from the community — what has broken for others trying similar approaches, with citations. |
 | [audience.md](audience.md) | Target-user segments and why each would adopt. Used for first-adopter outreach planning. |
 

--- a/docs/research/arxiv-papers.md
+++ b/docs/research/arxiv-papers.md
@@ -1,0 +1,21 @@
+# Academic papers — arxiv / peer-reviewed
+
+Capture: 2026-04-18. Pass intended to complement [prior-art.md](prior-art.md)'s "Academic landscape" note (which called the landscape "thin" and pointed only to confidential-compute attestation work). This file lists the handful of directly-relevant papers that a reviewer should actually be able to verify.
+
+Bar for inclusion: real arxiv ID or DOI, and a concrete tie-in to aegis-hwsim's scope (persona matrix, signed-chain rescue, attestation roundtrip, or the QEMU+OVMF+swtpm stack itself). Adjacent-but-not-useful papers excluded.
+
+## Papers
+
+1. **SoK: Security Below the OS — A Security Analysis of UEFI** — Surve, Brodt, Yampolskiy, Elovici, Shabtai (2023). arXiv:[2311.03809](https://arxiv.org/abs/2311.03809). Threat model + MITRE-ATT&CK-style taxonomy for UEFI attacks. Useful framing for *why* the persona matrix needs to cover SB-state and firmware-version variance — and as the canonical SoK citation in README `## Motivation`.
+
+2. **The State of Boot Integrity on Linux — a Brief Review** — ARES 2024, [doi:10.1145/3664476.3670910](https://doi.org/10.1145/3664476.3670910). Survey of shim/grub/systemd-boot/IMA/TPM ecosystem on Linux. Directly maps to the scope we test (Linux-visible signed-chain surface) and names the exact tooling gaps aegis-hwsim fills for test coverage.
+
+3. **Remote attestation of SEV-SNP confidential VMs using e-vTPMs** — Narayanan et al. (2023). arXiv:[2303.16463](https://arxiv.org/abs/2303.16463). PCR extend + TPM2_Quote benchmarks under vTPM. Relevant to the attestation-roundtrip scenario: establishes the reference shape of a correct measurement chain and the 5x vTPM latency gap — useful when sizing scenario timeouts.
+
+4. **UEFI Memory Forensics: A Framework for UEFI Threat Analysis** — Ben-Gurion University (2025). arXiv:[2501.16962](https://arxiv.org/abs/2501.16962). UefiMemDump / UEFIDumpAnalysis for detecting bootkits in pre-OS memory. Complementary — aegis-hwsim validates chain *integrity*; this validates chain *absence of hooks*. Potential future scenario if a persona needs to assert "no malicious image loaded".
+
+5. **FUZZUER: Enabling Fuzzing of UEFI Interfaces on EDK-2** — NDSS 2025, [paper PDF](https://www.ndss-symposium.org/wp-content/uploads/2025-400-paper.pdf). Static-analysis-driven harness generation for EDK-2 interfaces; found 20 vulns. Not overlap — they fuzz firmware-internal interfaces; we test OS-visible signed-chain flow. Referenceable as adjacent "harness design" prior art for our `qemu::Invocation` builder docs.
+
+## Explicit non-findings
+
+No paper found on **persona-matrix emulation testing** or **per-laptop-vendor SB conformance**. The academic literature continues to be dominated by fuzzing and vulnerability-discovery work, not functional conformance matrices — confirming prior-art.md's original "greenfield" characterization.

--- a/docs/research/recent-projects.md
+++ b/docs/research/recent-projects.md
@@ -1,0 +1,47 @@
+# Recent projects — 2025/2026 delta
+
+Capture: 2026-04-18. Delta-scan against [prior-art.md](prior-art.md). Covers projects that have appeared or materially evolved in the ~18 months before this pass.
+
+Honest summary: **the landscape is quiet**. The obvious tools (chipsec, fwts, edk2-SCT, LAVA, labgrid, openQA, fwupd CI, sbctl, puzzleos/uefi-dev, tompreston/qemu-ovmf-swtpm) remain the dominant set. No new persona-matrix harness has appeared.
+
+## Projects
+
+### anpep/qemu-tpm-measurement
+- URL: <https://github.com/anpep/qemu-tpm-measurement>
+- Language: shell / docs
+- Relationship: **Reference** (narrow-scope analog of our attestation scenario)
+- Why it matters: Minimal reproducer for QEMU+OVMF+swtpm boot-measurement + PCR-extend reads via `/sys/kernel/security/tpm0/binary_bios_measurements`. Useful sanity-check harness when debugging aegis-hwsim's TPM event-log capture path. Not a matrix — single config, manual.
+
+### intel/tsffs
+- URL: <https://github.com/intel/tsffs>
+- Language: Rust
+- Relationship: **Complementary** (orthogonal scope)
+- Why it matters: Snapshotting coverage-guided UEFI/BIOS/firmware fuzzer on SIMICS. Adjacent to aegis-hwsim's testable surface — they fuzz firmware-internal paths, we drive OS-visible signed-chain flows. Would pair well if a future aegis-hwsim consumer wanted fuzz-and-conformance in one CI.
+
+### fwupd SBAT plugin (new since fwupd 2.0.0, 2024)
+- URL: <https://fwupd.github.io/libfwupdplugin/uefi-sbat-README.html>
+- Language: C
+- Relationship: **Integration target** (future)
+- Why it matters: SBAT revocation delivery via LVFS became a real operational gap Jul 2024–Jan 2025. A future persona axis `sbat_generation:` would let aegis-hwsim assert rescue-stick behavior under stale-SBAT conditions — real-world failure mode currently untested.
+
+### systemd-ukify + UKI ecosystem
+- URL: <https://man.archlinux.org/man/ukify.1.en>, spec at <https://uapi-group.org/specifications/specs/unified_kernel_image/>
+- Language: Python (ukify), C (systemd-stub)
+- Relationship: **Integration target** (near-term)
+- Why it matters: UKIs collapse kernel+initrd+cmdline into one signed PE — changes what "signed-chain" means in practice. aegis-boot's USB-rescue-stick path needs a UKI-aware scenario now that distros (Arch, Fedora 40+, Debian testing) ship ukify as first-class. Worth a scenario added alongside signed-boot-ubuntu.
+
+## Explicit non-findings
+
+- **No sbctl-rs** found. sbctl remains Go-only; no Rust rewrite in progress that we could verify.
+- **No new persona-matrix harness** in the aegis-hwsim space. Existing tools still single-config.
+- **Dasharo** (<https://docs.dasharo.com/variants/qemu_q35/hardware-matrix/>) publishes a QEMU hardware matrix, but it's a *supported-configurations* list for their coreboot-based firmware product — not a test harness. Noted for completeness.
+
+## Implications for aegis-hwsim roadmap
+
+Two near-term ideas surface from this scan:
+
+1. **UKI scenario** — distros are shipping ukify-based kernels by default; aegis-boot's signed-chain assertion needs to cover `shim → systemd-stub → UKI` in addition to `shim → grub → kernel`. Worth a `signed-boot-uki` scenario alongside `signed-boot-ubuntu`.
+
+2. **SBAT-generation persona axis** — current personas pin `bios_version` but not SBAT generation. Real-world rescue-stick failures during the Jul 2024–Jan 2025 SBAT-revocation window suggest this is a coverage gap. Could be a follow-up persona-schema field added when a real operator hits the issue.
+
+Neither is urgent for v1.0; both are tracked here so future contributors find the rationale.

--- a/src/scenarios/common.rs
+++ b/src/scenarios/common.rs
@@ -1,0 +1,46 @@
+//! Helpers shared across scenario implementations. Kept tiny — only
+//! lift code here when at least three scenarios need it (DRY by
+//! extraction-when-it's-actually-duplicated, not pre-emptively).
+
+use std::path::Path;
+
+/// PATH lookup — splits the `PATH` env var on `:`, joins each entry
+/// with `binary`, and checks for an executable file. Used by every
+/// scenario's skip-gate to detect missing `qemu-system-x86_64` /
+/// `swtpm` cleanly.
+///
+/// Returns `false` when `PATH` is unset or no match is found. Does
+/// not check the executable bit — `is_file()` is enough on every
+/// platform aegis-hwsim targets (Linux + future macOS); a non-exec
+/// binary on `PATH` is a vanishingly rare misconfig that scenarios
+/// would catch via `Command::spawn()` anyway.
+#[must_use]
+pub fn binary_on_path(binary: &str) -> bool {
+    let Ok(path) = std::env::var("PATH") else {
+        return false;
+    };
+    for dir in path.split(':') {
+        let candidate = Path::new(dir).join(binary);
+        if candidate.is_file() {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_existing_binary() {
+        // sh is on PATH on every CI/dev machine we care about.
+        assert!(binary_on_path("sh"));
+    }
+
+    #[test]
+    fn misses_nonexistent_binary() {
+        assert!(!binary_on_path("definitely-not-a-binary-xyz-common-12345"));
+    }
+}

--- a/src/scenarios/mod.rs
+++ b/src/scenarios/mod.rs
@@ -1,6 +1,7 @@
 //! Concrete scenarios. Each module here implements
 //! [`crate::scenario::Scenario`] for one well-defined boot-flow assertion.
 
+pub mod common;
 pub mod qemu_boots_ovmf;
 pub mod signed_boot_ubuntu;
 

--- a/src/scenarios/qemu_boots_ovmf.rs
+++ b/src/scenarios/qemu_boots_ovmf.rs
@@ -17,6 +17,7 @@
 
 use crate::qemu::Invocation;
 use crate::scenario::{Scenario, ScenarioContext, ScenarioError, ScenarioResult};
+use crate::scenarios::common::binary_on_path;
 use crate::serial::SerialCapture;
 use crate::swtpm::{SwtpmInstance, SwtpmSpec};
 use std::time::Duration;
@@ -128,22 +129,6 @@ impl Scenario for QemuBootsOvmf {
             })
         }
     }
-}
-
-/// Same PATH lookup as the other scenarios. Duplicated for now — a
-/// future `scenarios::common` module can extract it when there's a
-/// third caller.
-fn binary_on_path(binary: &str) -> bool {
-    let Ok(path) = std::env::var("PATH") else {
-        return false;
-    };
-    for dir in path.split(':') {
-        let candidate = std::path::Path::new(dir).join(binary);
-        if candidate.is_file() {
-            return true;
-        }
-    }
-    false
 }
 
 #[cfg(test)]

--- a/src/scenarios/signed_boot_ubuntu.rs
+++ b/src/scenarios/signed_boot_ubuntu.rs
@@ -26,6 +26,7 @@
 
 use crate::qemu::Invocation;
 use crate::scenario::{Scenario, ScenarioContext, ScenarioError, ScenarioResult};
+use crate::scenarios::common::binary_on_path;
 use crate::serial::SerialCapture;
 use crate::swtpm::{SwtpmInstance, SwtpmSpec};
 use std::time::Duration;
@@ -126,23 +127,6 @@ impl Scenario for SignedBootUbuntu {
     }
 }
 
-/// Cheap PATH lookup — splits PATH on `:`, joins each entry with
-/// `binary`, and checks for an executable file. Used by the skip
-/// gates so missing tools yield SKIP rather than a confusing
-/// `SpawnFailed` at the QEMU/swtpm boundary.
-fn binary_on_path(binary: &str) -> bool {
-    let Ok(path) = std::env::var("PATH") else {
-        return false;
-    };
-    for dir in path.split(':') {
-        let candidate = std::path::Path::new(dir).join(binary);
-        if candidate.is_file() {
-            return true;
-        }
-    }
-    false
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
@@ -209,18 +193,6 @@ tpm:
         }
     }
 
-    /// PATH-based skip — covered indirectly here. We can't easily
-    /// install/uninstall qemu-system-x86_64 in unit tests, so the
-    /// real assertion is "`binary_on_path` returns false for nonsense
-    /// names and true for `sh`."
-    #[test]
-    fn binary_on_path_finds_existing_binary() {
-        // `sh` is on PATH on every CI/dev machine we care about.
-        assert!(binary_on_path("sh"));
-    }
-
-    #[test]
-    fn binary_on_path_misses_nonexistent_binary() {
-        assert!(!binary_on_path("definitely-not-a-binary-xyz-12345"));
-    }
+    // PATH-based skip is exercised by `binary_on_path` tests in
+    // `scenarios::common::tests`; not duplicated here.
 }


### PR DESCRIPTION
Two slices.

## Research index refresh

Spawned a research subagent to refresh the docs/research/ catalog. Two new files:

- **arxiv-papers.md** — five academic papers with verified arXiv IDs / DOIs tied to aegis-hwsim's scope (SoK on UEFI security, ARES 2024 boot integrity survey, SEV-SNP e-vTPM attestation, UEFI memory forensics 2025, FUZZUER from NDSS 2025). Each entry has a 2-sentence relevance line. Explicit non-finding: persona-matrix space remains greenfield.
- **recent-projects.md** — 2025/2026 delta-scan. Four projects with concrete relationships, plus a roadmap-implications note (UKI scenario + sbat_generation persona axis are worth adding when demand surfaces). Honest summary: 'the landscape is quiet'.

docs/research/README.md updated to index both new files.

## binary_on_path dedup

Both scenarios had identical PATH-lookup helpers with the comment 'duplicate for now — extract when there's a third caller'. We're not at three callers yet but the duplication had grown stale. New scenarios::common::binary_on_path; both scenarios import it; per-scenario tests dropped (covered in common::tests).

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test --locked (107 tests)
- [ ] CI green