### PR TITLE
feat(cli): --json sweep + version flag (matches aegis-boot family convention)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,20 @@ cargo build --release
 
 # Health-check the host first — surfaces all missing apt packages in
 # one pass instead of one-at-a-time via scenario Skip messages.
-target/release/aegis-hwsim doctor
+target/release/aegis-hwsim doctor               # Human-readable
+target/release/aegis-hwsim doctor --json        # schema_version=1 envelope
 
 # Inventory the shipped persona library
 target/release/aegis-hwsim list-personas
+target/release/aegis-hwsim list-personas --json
 
 # List registered scenarios
 target/release/aegis-hwsim list-scenarios
+target/release/aegis-hwsim list-scenarios --json
+
+# Version (matches aegis-boot --version --json convention for scriptable installs)
+target/release/aegis-hwsim --version
+target/release/aegis-hwsim --version --json
 
 # Smoke-test the harness pipeline (no signed stick needed)
 target/release/aegis-hwsim run qemu-smoke-no-tpm qemu-boots-ovmf /tmp/dummy.img
@@ -91,6 +98,8 @@ target/release/aegis-hwsim run \
   signed-boot-ubuntu \
   /path/to/aegis-boot.img
 ```
+
+Every read-mostly subcommand accepts `--json` and emits a `schema_version=1` envelope — matches the [aegis-boot family convention (PR #191)](https://github.com/williamzujkowski/aegis-boot/pull/191) so scripted consumers parse uniformly across the family.
 
 ### Exit codes
 

--- a/src/bin/aegis-hwsim.rs
+++ b/src/bin/aegis-hwsim.rs
@@ -24,7 +24,17 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Some("--version" | "version") => {
-            println!("aegis-hwsim v{}", env!("CARGO_PKG_VERSION"));
+            // Match aegis-boot --version --json (PR #205): scriptable
+            // consumers can parse without regex on the human string.
+            if args.iter().any(|a| a == "--json") {
+                println!("{{");
+                println!("  \"schema_version\": 1,");
+                println!("  \"tool\": \"aegis-hwsim\",");
+                println!("  \"version\": \"{}\"", env!("CARGO_PKG_VERSION"));
+                println!("}}");
+            } else {
+                println!("aegis-hwsim v{}", env!("CARGO_PKG_VERSION"));
+            }
             ExitCode::SUCCESS
         }
         Some(other) => {
@@ -290,9 +300,10 @@ fn run_doctor(args: &[String]) -> ExitCode {
         println!("aegis-hwsim doctor — check host has qemu/swtpm/ovmf installed");
         println!();
         println!("USAGE:");
-        println!("  aegis-hwsim doctor [--firmware-root DIR]");
+        println!("  aegis-hwsim doctor [--firmware-root DIR] [--json]");
         println!();
         println!("  --firmware-root DIR  Override OVMF dir (default: /usr/share/OVMF)");
+        println!("  --json               schema_version=1 envelope (matches family convention)");
         return ExitCode::SUCCESS;
     }
     let firmware_root = args
@@ -300,8 +311,13 @@ fn run_doctor(args: &[String]) -> ExitCode {
         .position(|a| a == "--firmware-root")
         .and_then(|i| args.get(i + 1))
         .map_or_else(|| PathBuf::from("/usr/share/OVMF"), PathBuf::from);
+    let json_mode = args.iter().any(|a| a == "--json");
     let report = aegis_hwsim::doctor::run(&firmware_root);
-    print!("{}", report.render());
+    if json_mode {
+        print!("{}", report.render_json());
+    } else {
+        print!("{}", report.render());
+    }
     if report.has_failures() {
         ExitCode::from(1)
     } else {
@@ -359,13 +375,25 @@ fn run_list_scenarios(args: &[String]) -> ExitCode {
     if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
         println!("aegis-hwsim list-scenarios — show registered test scenarios");
         println!();
-        println!("USAGE: aegis-hwsim list-scenarios");
+        println!("USAGE: aegis-hwsim list-scenarios [--json]");
+        println!();
+        println!("  --json    schema_version=1 envelope (matches family convention)");
         return ExitCode::SUCCESS;
     }
+    let json_mode = args.iter().any(|a| a == "--json");
     let registry = aegis_hwsim::scenario::Registry::default_set();
+    if json_mode {
+        print_scenarios_json(&registry);
+    } else {
+        print_scenarios_table(&registry);
+    }
+    ExitCode::SUCCESS
+}
+
+fn print_scenarios_table(registry: &aegis_hwsim::scenario::Registry) {
     if registry.is_empty() {
         println!("(no scenarios registered)");
-        return ExitCode::SUCCESS;
+        return;
     }
     println!("{:<28} DESCRIPTION", "NAME");
     for (name, desc) in registry.iter() {
@@ -373,7 +401,26 @@ fn run_list_scenarios(args: &[String]) -> ExitCode {
     }
     println!();
     println!("{} scenario(s).", registry.len());
-    ExitCode::SUCCESS
+}
+
+fn print_scenarios_json(registry: &aegis_hwsim::scenario::Registry) {
+    println!("{{");
+    println!("  \"schema_version\": 1,");
+    println!("  \"tool\": \"aegis-hwsim\",");
+    println!("  \"tool_version\": \"{}\",", env!("CARGO_PKG_VERSION"));
+    println!("  \"count\": {},", registry.len());
+    println!("  \"scenarios\": [");
+    let entries: Vec<_> = registry.iter().collect();
+    let last = entries.len().saturating_sub(1);
+    for (i, (name, desc)) in entries.iter().enumerate() {
+        let comma = if i == last { "" } else { "," };
+        println!("    {{");
+        println!("      \"name\": \"{}\",", json_escape(name));
+        println!("      \"description\": \"{}\"", json_escape(desc));
+        println!("    }}{comma}");
+    }
+    println!("  ]");
+    println!("}}");
 }
 
 /// Parsed argv for `run_scenario`. Owned by the caller; lifetimes

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -112,6 +112,67 @@ impl Report {
         let _ = writeln!(out, "NEXT ACTION: {}", self.next_action());
         out
     }
+
+    /// Render as `schema_version=1` JSON envelope. Matches the
+    /// [aegis-boot family --json convention](https://github.com/williamzujkowski/aegis-boot/pull/191):
+    /// `tool`, `tool_version`, plus a `next_action` summary alongside
+    /// the per-check rows so scripted consumers don't need to re-derive it.
+    #[must_use]
+    pub fn render_json(&self) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::with_capacity(self.checks.len() * 200);
+        out.push_str("{\n");
+        out.push_str("  \"schema_version\": 1,\n");
+        out.push_str("  \"tool\": \"aegis-hwsim\",\n");
+        let _ = writeln!(
+            out,
+            "  \"tool_version\": \"{}\",",
+            env!("CARGO_PKG_VERSION")
+        );
+        let _ = writeln!(
+            out,
+            "  \"next_action\": \"{}\",",
+            json_escape(&self.next_action())
+        );
+        let _ = writeln!(out, "  \"has_failures\": {},", self.has_failures());
+        let _ = writeln!(out, "  \"has_warnings\": {},", self.has_warnings());
+        out.push_str("  \"checks\": [\n");
+        let last = self.checks.len().saturating_sub(1);
+        for (i, c) in self.checks.iter().enumerate() {
+            let comma = if i == last { "" } else { "," };
+            out.push_str("    {\n");
+            let _ = writeln!(out, "      \"verdict\": \"{}\",", c.verdict.label());
+            let _ = writeln!(out, "      \"subject\": \"{}\",", json_escape(&c.subject));
+            let _ = writeln!(out, "      \"message\": \"{}\"", json_escape(&c.message));
+            let _ = writeln!(out, "    }}{comma}");
+        }
+        out.push_str("  ]\n");
+        out.push_str("}\n");
+        out
+    }
+}
+
+/// Minimal JSON string escape — matches the helper in
+/// `bin/aegis-hwsim.rs` + `coverage_grid.rs`. Duplicated here only
+/// because doctor doesn't depend on either; would extract to a shared
+/// `json` module if a fourth caller appeared.
+fn json_escape(s: &str) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 /// Run the doctor checks against `firmware_root`. Returns a [`Report`]
@@ -386,5 +447,58 @@ mod tests {
         assert!(s.contains("SUBJECT"));
         assert!(s.contains("MESSAGE"));
         assert!(s.contains("NEXT ACTION:"));
+    }
+
+    #[test]
+    fn render_json_emits_schema_version_envelope_and_checks_array() {
+        let (_tmp, root) = fake_firmware_root();
+        let r = run(&root);
+        let json = r.render_json();
+        assert!(json.contains("\"schema_version\": 1"));
+        assert!(json.contains("\"tool\": \"aegis-hwsim\""));
+        assert!(json.contains("\"tool_version\":"));
+        assert!(json.contains("\"next_action\":"));
+        assert!(json.contains("\"has_failures\":"));
+        assert!(json.contains("\"checks\": ["));
+        assert!(json.contains("\"verdict\":"));
+        assert!(json.contains("\"subject\":"));
+    }
+
+    #[test]
+    fn render_json_is_valid_json() {
+        // Hand-rolled emitter — round-trip through serde_json catches
+        // any escaping or comma-placement bug.
+        let (_tmp, root) = fake_firmware_root();
+        let r = run(&root);
+        let json = r.render_json();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("doctor --json output must parse");
+        assert_eq!(parsed["schema_version"], 1);
+        assert_eq!(parsed["tool"], "aegis-hwsim");
+        assert!(parsed["checks"].is_array());
+    }
+
+    #[test]
+    fn render_json_escapes_special_chars_in_messages() {
+        // Construct a synthetic Report with a message containing
+        // characters the escaper handles: quote, backslash, newline,
+        // tab, control char.
+        let r = Report {
+            checks: vec![Check {
+                verdict: Verdict::Warn,
+                subject: "test".into(),
+                message: "quote\" backslash\\ newline\n tab\t ctrl\x01 end".into(),
+            }],
+        };
+        let json = r.render_json();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("escaped output must still parse");
+        // serde_json normalizes escapes; round-trip recovers the original.
+        let msg = parsed["checks"][0]["message"].as_str().unwrap();
+        assert!(msg.contains("quote\""));
+        assert!(msg.contains("backslash\\"));
+        assert!(msg.contains("newline\n"));
+        assert!(msg.contains("tab\t"));
+        assert!(msg.contains('\x01'));
     }
 }


### PR DESCRIPTION
Three read-mostly subcommands now accept `--json`, completing the family-convention sweep that matches aegis-boot's #191 + #205 work. Scripted consumers (install one-liners, CI assertions, ansible-verified installs) parse uniformly across the family.

- `aegis-hwsim --version --json` → `{ schema_version, tool, version }`
- `aegis-hwsim doctor --json`    → adds `next_action`, `has_failures`, `has_warnings` summaries alongside the per-check rows
- `aegis-hwsim list-scenarios --json`

`list-personas` already had `--json` (PR #14); `coverage-grid` had `--format json` (PR #40); this finishes the sweep.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test --locked (110 tests, includes 3 new doctor JSON)
- [x] All three new --json outputs locally parseable by `python3 -m json.tool`
- [ ] CI green