### PR TITLE
fix(qemu): drop invalid -smbios type=3 emission + correct signed-boot-ubuntu landmarks (real-stick validated)

### DIFF
--- a/src/scenarios/signed_boot_ubuntu.rs
+++ b/src/scenarios/signed_boot_ubuntu.rs
@@ -37,13 +37,32 @@ const LANDMARK_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// The boot-chain landmarks we wait for, in order. Each one's
 /// observation is necessary for the chain to be considered Pass.
+///
+/// Empirical check (2026-04-18, against a real signed stick on a
+/// Framework Laptop): shim itself is silent on serial unless
+/// `SHIM_VERBOSE=1` is set, so we observe its work via the GRUB hand-
+/// off. The landmarks below are direct quotes from a successful boot
+/// of a v0.11.0 aegis-boot stick:
+///
+/// 1. `BdsDxe: starting Boot0001` — OVMF launched the stick's
+///    `\EFI\BOOT\BOOTX64.EFI` (which is shim).
+/// 2. `GNU GRUB` — shim's signed-chain verification of grub passed;
+///    grub is now running. Distros print this consistently.
+/// 3. `EFI stub: UEFI Secure Boot is enabled` — kernel started, SB
+///    state propagated to the kernel command line. This is the
+///    canonical signed-chain-reached-kernel marker.
+/// 4. `rescue-tui starting` — userspace rescue UI alive, meaning
+///    the initramfs ran to completion.
+///
+/// Reaching landmark 4 means the full signed chain (OVMF → shim →
+/// grub → kernel → initramfs → rescue-tui) completed successfully.
+/// kexec into a target ISO is operator choice, not a chain-validity
+/// signal — we don't assert it here.
 const LANDMARKS: &[&str] = &[
-    "shim",
-    // grub may print as "grub", "GNU GRUB", or `Welcome to GRUB`. We
-    // match the broadest substring to tolerate distro variation.
-    "GRUB",
-    "Linux version",
-    "kexec_core: Starting new kernel",
+    "BdsDxe: starting Boot0001",
+    "GNU GRUB",
+    "EFI stub: UEFI Secure Boot is enabled",
+    "rescue-tui starting",
 ];
 
 /// The first end-to-end scenario. Stateless; all per-run state lives

--- a/src/smbios.rs
+++ b/src/smbios.rs
@@ -91,11 +91,19 @@ pub fn smbios_argv(dmi: &Dmi) -> Result<Vec<String>, SmbiosError> {
         ));
     }
 
-    // type=3 — Chassis (only when chassis_type is set)
-    if let Some(ct) = dmi.chassis_type {
-        argv.push("-smbios".to_string());
-        argv.push(format!("type=3,type={ct}"));
-    }
+    // type=3 — System Enclosure. We DON'T emit one even when
+    // `dmi.chassis_type` is set: QEMU's `-smbios type=3` accepts
+    // manufacturer/version/serial/asset/sku but does NOT expose the
+    // chassis-type code (3=desktop, 10=notebook, etc.) as a
+    // settable field. Emitting `type=3,type={ct}` is parsed by QEMU
+    // as "switch to SMBIOS type {ct}" and rejected for unknown types
+    // (real-world failure: 2026-04-18 against the Framework persona,
+    // QEMU said `Don't know how to build fields for SMBIOS type 10`).
+    //
+    // The persona's chassis_type field is preserved as informational
+    // metadata that future readers can use; we just don't pass it to
+    // QEMU. If/when QEMU exposes the field, switch this back on.
+    let _ = &dmi.chassis_type;
 
     Ok(argv)
 }
@@ -171,11 +179,18 @@ mod tests {
     }
 
     #[test]
-    fn emits_type3_when_chassis_type_set() {
+    fn does_not_emit_type3_even_when_chassis_type_set() {
+        // QEMU's `-smbios type=3` doesn't accept a chassis-type code
+        // field; emitting `type=3,type=N` is parsed as "switch SMBIOS
+        // type to N" and rejected. We deliberately drop it. The
+        // persona's chassis_type stays as informational metadata.
         let mut d = minimal_dmi();
         d.chassis_type = Some(10); // notebook
         let argv = smbios_argv(&d).unwrap();
-        assert!(argv.iter().any(|a| a == "type=3,type=10"));
+        assert!(
+            !argv.iter().any(|a| a.starts_with("type=3")),
+            "must not emit `-smbios type=3`; got {argv:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
**End-to-end signed-chain boot validated against a real signed aegis-boot stick.** User attached a SanDisk Cruzer; first scenario run surfaced two real bugs that CI's smoke didn't catch.

## Bug 1: `-smbios type=3,type={ct}` rejected by QEMU

Our smbios.rs emitted `-smbios type=3,type={ct}` for personas with `dmi.chassis_type` set. QEMU parses comma-separated `type=N` as 'switch SMBIOS structure type to N', so `type=3,type=10` was interpreted as wanting SMBIOS type 10 (Onboard Devices) — which QEMU rejects:

```
qemu-system-x86_64: -smbios type=3,type=10:
  Don't know how to build fields for SMBIOS type 10
```

QEMU's `-smbios type=3` accepts manufacturer/version/serial/asset/sku but does NOT expose the chassis-type code as a settable field. Fix: drop the type=3 emission entirely; preserve `chassis_type` as informational metadata in the persona.

CI didn't catch this because qemu-smoke-no-tpm doesn't set chassis_type.

## Bug 2: signed-boot-ubuntu landmarks didn't match reality

Original landmarks (shim / GRUB / Linux version / kexec_core) were guesses. Real-world output:

- shim is **silent** on serial unless SHIM_VERBOSE=1
- kexec_core only fires if the operator chose to kexec a target ISO

Replaced with landmarks copied verbatim from the successful boot:

1. `BdsDxe: starting Boot0001`              → OVMF launched the stick
2. `GNU GRUB`                               → shim verified grub
3. `EFI stub: UEFI Secure Boot is enabled`  → kernel running under SB
4. `rescue-tui starting`                    → initramfs ran to completion

## Result

```
$ aegis-hwsim run framework-laptop-12gen signed-boot-ubuntu ~/aegis-hwsim-test/aegis-stick.img
PASS: signed-boot-ubuntu on framework-laptop-12gen
```

The deferred E3 child item (real-stick end-to-end test) is now genuinely satisfied. The harness validates against a real signed stick on the matching persona.

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test --locked (113 tests; smbios test updated to assert new behavior)
- [x] aegis-hwsim run framework-laptop-12gen signed-boot-ubuntu &lt;real-stick.img&gt; → PASS
- [ ] CI green