### PR TITLE
feat(coverage-grid): --stick + --firmware-root flags + /tmp work dir

### DIFF
--- a/src/bin/aegis-hwsim.rs
+++ b/src/bin/aegis-hwsim.rs
@@ -334,11 +334,17 @@ fn run_coverage_grid(args: &[String]) -> ExitCode {
         println!("aegis-hwsim coverage-grid — emit persona × scenario matrix");
         println!();
         println!("USAGE:");
-        println!("  aegis-hwsim coverage-grid [--format json|markdown] [--dry-run]");
+        println!(
+            "  aegis-hwsim coverage-grid [--format json|markdown] [--dry-run] \\\n\
+             \x20             [--stick PATH] [--firmware-root DIR]"
+        );
         println!();
-        println!("  --format markdown  Human-readable table (default)");
-        println!("  --format json      schema_version=1 envelope");
-        println!("  --dry-run          Skip every cell with reason='dry-run'");
+        println!("  --format markdown      Human-readable table (default)");
+        println!("  --format json          schema_version=1 envelope");
+        println!("  --dry-run              Skip every cell with reason='dry-run'");
+        println!("  --stick PATH           Stick image to use for stick-needing scenarios.");
+        println!("                         Falls back to AEGIS_HWSIM_STICK env var.");
+        println!("  --firmware-root DIR    Override OVMF dir (default: /usr/share/OVMF)");
         return ExitCode::SUCCESS;
     }
     let format = if args.iter().any(|a| a == "json") {
@@ -348,17 +354,36 @@ fn run_coverage_grid(args: &[String]) -> ExitCode {
     };
     let dry_run = args.iter().any(|a| a == "--dry-run");
 
+    let stick = args
+        .iter()
+        .position(|a| a == "--stick")
+        .and_then(|i| args.get(i + 1))
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("AEGIS_HWSIM_STICK").map(PathBuf::from))
+        .unwrap_or_else(|| PathBuf::from("/no/stick/configured"));
+
+    let firmware_root = args
+        .iter()
+        .position(|a| a == "--firmware-root")
+        .and_then(|i| args.get(i + 1))
+        .map_or_else(|| PathBuf::from("/usr/share/OVMF"), PathBuf::from);
+
     let personas = match load_or_report() {
         Ok(p) => p,
         Err(code) => return ExitCode::from(code),
     };
     let registry = aegis_hwsim::scenario::Registry::default_set();
 
-    let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    // Work dirs under /tmp rather than cwd: the Unix socket path
+    // (Linux limit 108 chars) caps how deep we can nest. cwd-based
+    // paths overflow on long persona+scenario combinations
+    // (lenovo-thinkpad-x1-carbon-gen11__signed-boot-ubuntu →
+    // 121-char swtpm.sock path → "UnioIO socket is too long" + cell
+    // FAIL). /tmp/ahwsim-cov keeps the prefix to ~17 chars.
     let cfg = aegis_hwsim::coverage_grid::GridConfig {
-        work_root: cwd.join("work").join("coverage-grid"),
-        firmware_root: PathBuf::from("/usr/share/OVMF"),
-        stick: PathBuf::from("/no/stick/configured"),
+        work_root: PathBuf::from("/tmp/ahwsim-cov"),
+        firmware_root,
+        stick,
         dry_run,
     };
     let cells = aegis_hwsim::coverage_grid::compute_grid(&personas, &registry, &cfg);


### PR DESCRIPTION
Live coverage-grid against the real Framework signed stick exposed three issues. All fixed in this PR.

## Bugs

1. **No way to pass a stick to the matrix.** signed-boot-ubuntu cells always Skip. Added `--stick PATH` + AEGIS_HWSIM_STICK env var fallback.
2. **No way to override firmware_root.** Matched aegis-hwsim run's convention: `--firmware-root DIR`.
3. **Unix socket path overflow.** swtpm refused to bind because the per-cell work_dir blew past Linux's 108-char sun_path limit on long persona+scenario combinations. Switched work_root from `<cwd>/work/coverage-grid/` to `/tmp/ahwsim-cov/` (saves ~13 chars).

## Live grid result against real stick

After all three fixes, every TPM-bearing persona PASSes signed-boot-ubuntu against the same physical stick:

```
| persona | qemu-boots-ovmf | signed-boot-ubuntu |
|---|---|---|
| asus-zenbook-14-oled | SKIP | PASS |
| dell-xps-13-9320 | SKIP | PASS |
| framework-laptop-12gen | SKIP | PASS |
| hp-elitebook-845-g10 | SKIP | PASS |
| lenovo-thinkpad-t440p-tpm12 | SKIP | PASS |  ← TPM 1.2 via tpm-tis
| lenovo-thinkpad-x1-carbon-gen11 | SKIP | PASS |
| qemu-generic-minimal | SKIP | PASS |
| qemu-smoke-no-tpm | PASS | PASS |
| qemu-disabled-sb | PASS | FAIL |  ← correct: no SB
| qemu-setup-mode-sb | PASS | FAIL |  ← correct: blank VARS
| qemu-custom-pk-sb | ERROR | ERROR |  ← firmware_root mismatch (known)
```

This is the real-world matrix value the harness was built for: the same signed stick boots cleanly across 6 different laptop DMI/firmware profiles AND across both TPM versions (2.0 fTPM/PTT/discrete + 1.2 ST33 via tpm-tis).

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo test --locked
- [x] coverage-grid --stick PATH against real Framework stick — 7 personas PASS, semantic FAILs/SKIPs as expected
- [ ] CI green