### PR TITLE
ci: bump Node-20-based actions to v5 (closes #59)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Rust
         run: |
           rustup toolchain install 1.85.0 --profile minimal --component clippy,rustfmt
@@ -35,7 +35,7 @@ jobs:
           cargo run --locked -q --bin aegis-hwsim -- coverage-grid > artifacts/coverage-grid.md
           cargo run --locked -q --bin aegis-hwsim -- coverage-grid --format json > artifacts/coverage-grid.json
       - name: Upload coverage-grid artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-grid
           path: artifacts/coverage-grid.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to aegis-hwsim. Mirrors the [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
-_Nothing yet. Work since 0.0.2 lands here._
+### CI
+
+- **Bump Node-20-based GitHub Actions to Node-24-compatible v5** (closes [#59](https://github.com/williamzujkowski/aegis-hwsim/issues/59)) — `actions/checkout@v4 → @v5` and `actions/upload-artifact@v4 → @v5` in `.github/workflows/ci.yml`. Closes the deprecation banner runners surface ("Node.js 20 actions are deprecated… Node.js 20 will be removed from the runner on September 16th, 2026"). Single-line changes; v5 is backward-compatible with the explicit `retention-days: 30` and `if-no-files-found: error` settings we use.
 
 ## [0.0.2] — 2026-04-18
 


### PR DESCRIPTION
## Summary

Closes [#59](https://github.com/williamzujkowski/aegis-hwsim/issues/59) — every CI job currently surfaces this annotation:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20: \`actions/checkout@v4\`, \`actions/upload-artifact@v4\`. Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed from the runner on **September 16th, 2026**.

Single-line bumps:
- \`actions/checkout@v4\` → \`@v5\`
- \`actions/upload-artifact@v4\` → \`@v5\`

## Compatibility check

\`actions/upload-artifact@v5\` preserves the \`retention-days\` and \`if-no-files-found\` inputs we use; no other workflow changes needed.

## Test plan

- [x] CI runs on this PR — green = the bump is safe for our config
- [x] Annotation banner should disappear from this PR's run

🤖 Generated with [Claude Code](https://claude.com/claude-code)