### PR TITLE
chore(publish): add exclude list + README badges for v1.0.0 gate (#7)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,18 @@ homepage = "https://github.com/williamzujkowski/aegis-hwsim"
 readme = "README.md"
 keywords = ["qemu", "ovmf", "uefi", "testing", "secure-boot"]
 categories = ["development-tools::testing", "emulators"]
+# Exclude dev-facing files from `cargo package` so `cargo install` /
+# crates.io downloads stay lean and ship no placeholder fixtures that
+# could be mistaken for real keyring material. Per E7 (#7) audit
+# 2026-04-19. Tests + their fixtures stay — they're needed for
+# `cargo test` on consumers' machines.
+exclude = [
+    "CLAUDE.md",
+    ".github/**",
+    "firmware/test-keyring/**",
+    "docs/research/**",
+    "scenarios/README.md",
+]
 
 [[bin]]
 name = "aegis-hwsim"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # aegis-hwsim
 
+[![CI](https://github.com/williamzujkowski/aegis-hwsim/actions/workflows/ci.yml/badge.svg)](https://github.com/williamzujkowski/aegis-hwsim/actions/workflows/ci.yml)
+[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue)](./Cargo.toml)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](./LICENSE-MIT)
+
+<!-- crates.io + docs.rs badges pending first `cargo publish` (tracked: E7 #7) -->
+
 **Status:** Phase 1 working. CI exercises the full QEMU+OVMF+swtpm pipeline against the persona library on every PR via the `qemu-boots-ovmf` smoke scenario. Tracks [aegis-boot#226](https://github.com/williamzujkowski/aegis-boot/issues/226).
 
 A test harness that parameterizes **QEMU + OVMF + swtpm** over a matrix of **hardware personas** — YAML fixtures matching real shipping laptops/workstations — so [aegis-boot](https://github.com/williamzujkowski/aegis-boot)'s UEFI-Secure-Boot-preserving USB-rescue-stick flow can be validated across ~100 configurations without waiting on physical Framework / ThinkPad / Dell / HP / ASUS hardware.


### PR DESCRIPTION
## Summary

First follow-up from the 2026-04-19 [#7 publish-readiness audit](https://github.com/williamzujkowski/aegis-hwsim/issues/7#issuecomment-4275288775). Two minimal, reversible changes toward the crates.io publish gate — no version bump, no behaviour change.

## Changes

### 1. \`[package].exclude\` trims dev-only files from the crate tarball

Before: **67 files / ~1.2 MB tarball** (includes placeholder test keyring blob + internal dev docs)
After: **51 files / 308 KB tarball** (86 KB compressed)

Excluded:
- \`CLAUDE.md\` — internal dev instructions
- \`.github/**\` — CI config
- \`firmware/test-keyring/**\` — 1 MB pseudo-random placeholder \`.fd\` file + its README. Per E7 checklist \"refuse publish if any TEST_ONLY hit\" — the file isn't real key material but shipping it risks consumer confusion
- \`docs/research/**\` — 11 dev-facing research notes
- \`scenarios/README.md\` — the scenarios *source* dir ships via \`src/scenarios/\`

Preserved:
- \`tests/fixtures/bad-*.yaml\` — needed by the published \`tests/\` for consumer \`cargo test\`
- \`personas/*.yaml\` — including \`qemu-custom-pk-sb.yaml\` which references the excluded keyring; verified \`tests/loads_real_personas.rs\` still passes because \`check_custom_keyring\` falls back to uncanonicalized starts_with when the \`.fd\` file is absent (intentional — see \`src/loader.rs:296-316\`)

### 2. README badges

Added CI + MSRV + License badges at the top of README. crates.io + docs.rs badges left commented-out until the first \`cargo publish\` creates the targets they need.

## Not in this PR

- **Version bump to 1.0.0** — per #7 gate sequence, lands in a separate PR alongside the real-hardware comparison study
- **\`serde_yaml\` migration** — transitive noise during \`cargo publish\`; filed as its own tech-debt issue (link below once filed)
- **Cross-repo coordination on aegis-boot#51/#132/#181** — post-publish work

## Test plan

- [x] \`cargo test\` — 110 tests pass
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo package\` — build + verify succeeds, 51-file / 308 KB tarball
- [x] Tarball manually inspected — no dev files, no placeholder keyring blob
- [ ] CI green

Part of [#7](https://github.com/williamzujkowski/aegis-hwsim/issues/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)