### PR TITLE
tech-debt: migrate serde_yaml 0.9 → serde_yaml_ng 0.10 (closes #62)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "tempfile",
  "thiserror",
 ]
@@ -298,10 +298,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ path = "src/bin/aegis-hwsim.rs"
 # aegis-boot chose hand-rolled argv; stay consistent across the family.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml_ng = "0.10"
 schemars = "0.8"
 thiserror = "2"
 

--- a/src/coverage_grid.rs
+++ b/src/coverage_grid.rs
@@ -330,7 +330,7 @@ tpm:
   version: none
 "
         );
-        serde_yaml::from_str(&yaml).unwrap()
+        serde_yaml_ng::from_str(&yaml).unwrap()
     }
 
     /// A minimal scenario for grid tests — always returns the result

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -5,7 +5,7 @@
 //! Guards implemented here (aegis-hwsim#8):
 //!
 //! * **Parse** — YAML syntax and serde structural validation (missing
-//!   fields, wrong types). Comes from `serde_yaml`; we wrap the error.
+//!   fields, wrong types). Comes from `serde_yaml_ng`; we wrap the error.
 //! * **`IdMismatch`** — `persona.id` must equal the filename stem (without
 //!   `.yaml`). Catches the common rename-one-forget-the-other bug.
 //! * **Placeholder** — no `TEST_ONLY_NOT_FOR_PRODUCTION` token may appear
@@ -49,7 +49,7 @@ pub enum LoadError {
         path: PathBuf,
         /// Underlying parser error.
         #[source]
-        source: serde_yaml::Error,
+        source: serde_yaml_ng::Error,
     },
 
     /// `persona.id` doesn't match the filename stem.
@@ -167,7 +167,7 @@ fn load_one(path: &Path, opts: &LoadOptions) -> Result<Persona, LoadError> {
         path: path.to_path_buf(),
         source,
     })?;
-    let persona: Persona = serde_yaml::from_str(&body).map_err(|source| LoadError::Parse {
+    let persona: Persona = serde_yaml_ng::from_str(&body).map_err(|source| LoadError::Parse {
         path: path.to_path_buf(),
         source,
     })?;

--- a/src/persona.rs
+++ b/src/persona.rs
@@ -265,7 +265,7 @@ secure_boot:
 tpm:
   version: "2.0"
 "#;
-        let p: Persona = serde_yaml::from_str(yaml).unwrap();
+        let p: Persona = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(p.id, "qemu-generic-minimal");
         assert_eq!(p.dmi.sys_vendor, "QEMU");
         assert!(matches!(

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -237,7 +237,7 @@ mod tests {
 
     fn fake_ctx() -> ScenarioContext {
         ScenarioContext {
-            persona: serde_yaml::from_str(
+            persona: serde_yaml_ng::from_str(
                 r#"
 schema_version: 1
 id: fake

--- a/src/scenarios/qemu_boots_ovmf.rs
+++ b/src/scenarios/qemu_boots_ovmf.rs
@@ -139,7 +139,7 @@ mod tests {
     use std::path::PathBuf;
 
     fn no_tpm_persona() -> Persona {
-        serde_yaml::from_str(
+        serde_yaml_ng::from_str(
             "
 schema_version: 1
 id: smoke-test

--- a/src/scenarios/signed_boot_ubuntu.rs
+++ b/src/scenarios/signed_boot_ubuntu.rs
@@ -154,7 +154,7 @@ mod tests {
     use std::path::PathBuf;
 
     fn make_persona(yaml: &str) -> Persona {
-        serde_yaml::from_str(yaml).unwrap()
+        serde_yaml_ng::from_str(yaml).unwrap()
     }
 
     fn base_persona_yaml() -> &'static str {


### PR DESCRIPTION
## Summary

Mechanical swap from \`serde_yaml 0.9.34+deprecated\` → \`serde_yaml_ng 0.10\`. The \`+deprecated\` suffix was upstream dtolnay's self-signal: the original crate is archived and no longer accepts fixes. \`serde_yaml_ng\` is the API-compatible active fork.

Closes [#62](https://github.com/williamzujkowski/aegis-hwsim/issues/62).

## Changes

- \`Cargo.toml\` — one line swap
- 7 \`serde_yaml::\` → \`serde_yaml_ng::\` call sites across:
  - \`src/persona.rs\` (unit test)
  - \`src/scenarios/signed_boot_ubuntu.rs\` (unit test)
  - \`src/scenarios/qemu_boots_ovmf.rs\` (unit test)
  - \`src/loader.rs\` (error type + \`from_str\` call + doc comment)
  - \`src/scenario.rs\` (unit test)
  - \`src/coverage_grid.rs\` (unit test)

## Test plan

- [x] \`cargo test\` — all 110 tests pass (91 unit + 10 loader integration + 5 negative_fixtures + 4 others)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`tests/negative_fixtures.rs\` error-string assertions unchanged — \`serde_yaml_ng\` preserves the same error messaging shape
- [ ] CI green

## Not in this PR

- No version bump — still v0.0.2; v1.0.0 lands per #7 gate sequence
- No API changes exposed to consumers — \`LoadError::Parse\`'s \`source\` field type changed from \`serde_yaml::Error\` → \`serde_yaml_ng::Error\` but both implement \`std::error::Error\` so pattern matches via trait object don't break

🤖 Generated with [Claude Code](https://claude.com/claude-code)