### PR TITLE
docs: post-Phase-2 accuracy sweep (CLAUDE.md, README.md, CONTRIBUTING.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,10 +110,15 @@ The parent session that spun up this repo has memory notes at `/home/william/.cl
 
 ## Status
 
-**Scaffolding phase.** Subcommands currently exit 3 with "not implemented". Phase 1 target per [aegis-boot#226](https://github.com/williamzujkowski/aegis-boot/issues/226):
+**Phase 1 + Phase 2 complete** (v0.0.2, 2026-04-18 per `CHANGELOG.md`). All subcommands (`doctor`, `list-personas`, `list-scenarios`, `gen-schema`, `coverage-grid`, `run`, `--version`) implemented and exercised on CI. 11 personas covering all 4 OVMF variants and all 3 TPM versions; 2 scenarios (`qemu-boots-ovmf` smoke + `signed-boot-ubuntu` end-to-end); 113 tests including 60k random-input fuzz per CI run.
 
-- [x] Persona schema + 3 starter fixtures
-- [x] Research index + prior-art survey
-- [ ] Runner: persona loader + `aegis-hwsim validate`
-- [ ] Runner: QEMU synthesis for `signed-boot-ubuntu` scenario
-- [ ] CI matrix job producing coverage grid artifact
+Tracking issues for next phases:
+
+- [#5](https://github.com/williamzujkowski/aegis-hwsim/issues/5) — E5: MOK + unsigned-kexec scenarios (phase-2)
+- [#6](https://github.com/williamzujkowski/aegis-hwsim/issues/6) — E6: attestation + TPM-varied personas (phase-2)
+- [#7](https://github.com/williamzujkowski/aegis-hwsim/issues/7) — E7: v1.0 release gate (phase-3)
+
+Feature proposals currently blocked on upstream signal (do not pre-build):
+
+- [#50](https://github.com/williamzujkowski/aegis-hwsim/issues/50) — signed-boot-uki scenario (blocked on UKI-formatted aegis-boot stick artifact)
+- [#51](https://github.com/williamzujkowski/aegis-hwsim/issues/51) — sbat_generation persona axis (blocked on first real-world hardware-report flagging SBAT failure)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Then read [docs/architecture.md](docs/architecture.md) before opening a non-triv
 | New test for an existing module | Yes | Especially edge cases the fuzz didn't catch. |
 | Refactor that improves clarity | Yes | Must keep all existing tests green + add a test if it caught a real defect. |
 | Refactor "for cleanness" with no test improvement | No | We avoid churn. See aegis-boot CLAUDE.md "refactor threshold" §. |
-| New dependency | Discuss first | Open an issue. The crate currently uses serde, serde_json, serde_yaml, schemars, thiserror, and tempfile (dev). Each addition is justified. |
+| New dependency | Discuss first | Open an issue. The crate currently uses serde, serde_json, serde_yaml_ng, schemars, thiserror, and tempfile (dev). Each addition is justified. |
 | New CLI subcommand | Yes if scoped | Must have a `--help` line + `print_help` entry. |
 
 ## Source-citation policy

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <!-- crates.io + docs.rs badges pending first `cargo publish` (tracked: E7 #7) -->
 
-**Status:** Phase 1 working. CI exercises the full QEMU+OVMF+swtpm pipeline against the persona library on every PR via the `qemu-boots-ovmf` smoke scenario. Tracks [aegis-boot#226](https://github.com/williamzujkowski/aegis-boot/issues/226).
+**Status:** Phase 1 + Phase 2 complete (v0.0.2, 2026-04-18) — 11 personas covering all 4 OVMF variants and all 3 TPM versions, 2 scenarios (`qemu-boots-ovmf` smoke + `signed-boot-ubuntu` end-to-end), coverage-grid artifact per PR, 113 tests including 60k-input fuzz per CI run. Tracks [aegis-boot#226](https://github.com/williamzujkowski/aegis-boot/issues/226); next phases tracked in [#5](https://github.com/williamzujkowski/aegis-hwsim/issues/5) / [#6](https://github.com/williamzujkowski/aegis-hwsim/issues/6) / [#7](https://github.com/williamzujkowski/aegis-hwsim/issues/7).
 
 A test harness that parameterizes **QEMU + OVMF + swtpm** over a matrix of **hardware personas** — YAML fixtures matching real shipping laptops/workstations — so [aegis-boot](https://github.com/williamzujkowski/aegis-boot)'s UEFI-Secure-Boot-preserving USB-rescue-stick flow can be validated across ~100 configurations without waiting on physical Framework / ThinkPad / Dell / HP / ASUS hardware.
 


### PR DESCRIPTION
## Summary

Surfaced by a scheduled accuracy audit of the three top-level docs against actual v0.0.2 state.

| File | Was | Is |
|---|---|---|
| CLAUDE.md | "Scaffolding phase. Subcommands currently exit 3 with 'not implemented'" + unchecked Phase 1 boxes | Phase 1 + 2 complete per v0.0.2 CHANGELOG; links tracking issues #5 / #6 / #7 and blocked features #50 / #51 |
| CONTRIBUTING.md | Lists \`serde_yaml\` as an active dep | Lists \`serde_yaml_ng\` per PR #63 (closes #62) |
| README.md Status line | "Phase 1 working" | "Phase 1 + Phase 2 complete" with the shipped-scope numbers |

No code changes.

## Test plan

- [x] Diff is docs-only (no .rs / Cargo.toml / .yaml changes)
- [x] Cross-checked each claim against CHANGELOG \`## [0.0.2] — 2026-04-18\` entry
- [x] Verified \`ls personas/*.yaml\` = 11 + scenarios = 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)