### PR TITLE
chore(cargo): add documentation field for docs.rs link (E7 #7)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "QEMU+OVMF+swtpm hardware-persona matrix harness for aegis-boot signed-chain testing"
 repository = "https://github.com/williamzujkowski/aegis-hwsim"
 homepage = "https://github.com/williamzujkowski/aegis-hwsim"
+documentation = "https://docs.rs/aegis-hwsim"
 readme = "README.md"
 keywords = ["qemu", "ovmf", "uefi", "testing", "secure-boot"]
 categories = ["development-tools::testing", "emulators"]


### PR DESCRIPTION
## Summary

One-line Cargo.toml addition: \`documentation = \"https://docs.rs/aegis-hwsim\"\`.

Closes the last gap in E7 (v1.0 release gate) child item _\"Cargo metadata for crates.io publish: categories, keywords, readme, documentation, homepage, repository\"_. All other fields already present.

### E7 progress sidecar (verified as part of this change)

- \`cargo publish --dry-run --allow-dirty\` → clean (compiles, packages, upload aborted only because --dry-run)
- \`grep TEST_ONLY_NOT_FOR_PRODUCTION\` across src/ + tests/fixtures/ → clean (all hits are the detection code + guard test fixture, no key material)

### Remaining E7 items (not blocked by this PR)

- Crate README crates.io + docs.rs badges — chicken-and-egg: the badge URLs need a real published crate to point at. Defer until post-publish.
- Real-hardware comparison study — needs physical hardware runs; not LLM-tractable.
- Tag + \`cargo publish\` — human gate; this PR adds to the publishable surface, does not trigger publish.

## Test plan

- [x] \`cargo publish --dry-run --allow-dirty\` clean
- [x] \`cargo fmt --all -- --check\` clean (Cargo.toml is TOML, not Rust; fmt doesn't touch it, still ran to verify no other drift)
- [x] Single-line diff in Cargo.toml only

🤖 Generated with [Claude Code](https://claude.com/claude-code)