### PR TITLE
feat(ci): trusted-publishing workflow + idempotent publish wrapper

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -1,0 +1,60 @@
+name: Publish to crates.io (trusted publishing)
+
+# Trusted Publishing to crates.io — NO long-lived CARGO_REGISTRY_TOKEN.
+# The aegis-hwsim crate is configured on crates.io with a trusted
+# publisher pointing at this workflow + the `release` environment.
+# rust-lang/crates-io-auth-action exchanges the GitHub OIDC token
+# for a short-lived (~30 min) crates.io token consumed by
+# `cargo publish` via scripts/publish-if-new.sh.
+#
+# Mirrors the `aegis-boot/aegis-boot` publish workflow; same
+# scripts/publish-if-new.sh wrapper makes the publish idempotent
+# (skip + exit 0 if already at the workspace version, no
+# cascade-fail).
+#
+# Triggers:
+#   - Tagged releases (v*.*.* / v*.*.*-*)
+#   - workflow_dispatch for manual republish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+  workflow_dispatch:
+
+# Single-publish-at-a-time so we never race two tag pushes.
+concurrency:
+  group: crates-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: cargo publish (trusted)
+    runs-on: ubuntu-latest
+    # Environment gate: tag-scoped to `v*` (only signed v* tag
+    # pushes can enter — branches cannot publish). No required-
+    # reviewer rule — autonomous bug-fix releases per the
+    # aegis-boot/aegis-boot precedent (2026-04-22).
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain (pinned)
+        run: |
+          rustup toolchain install 1.85.0 --profile minimal --no-self-update
+          rustup default 1.85.0
+          rustc --version
+
+      - name: Mint short-lived crates.io token (OIDC)
+        uses: rust-lang/crates-io-auth-action@v1
+        id: cio_auth
+
+      - name: publish aegis-hwsim
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.cio_auth.outputs.token }}
+        run: ./scripts/publish-if-new.sh aegis-hwsim

--- a/scripts/publish-if-new.sh
+++ b/scripts/publish-if-new.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# publish-if-new.sh — idempotent `cargo publish` wrapper.
+#
+# Compares the workspace version (from $WORKSPACE_VERSION env or
+# `Cargo.toml [workspace.package].version`) against the highest
+# version of $1 currently on crates.io. If they match, exits 0
+# with a clean "already published" log line. Otherwise runs
+# `cargo publish -p $1 --locked` and propagates its exit code.
+#
+# Why this exists: the trusted-publishing release workflow
+# publishes 6 crates in one job. If a previous re-trigger (or a
+# parallel manual publish) already pushed one of them at the
+# current version, the next run's `cargo publish` for THAT crate
+# returns a 400-ish "version already exists" error and — without
+# this wrapper — fails the step, cascade-skipping all subsequent
+# crate publishes.
+#
+# This wrapper turns the "already at this version" case into a
+# clean no-op so the workflow can keep going. Any OTHER cargo
+# publish failure (network, auth, validation) still fails
+# loudly with the original cargo exit code.
+#
+# Usage:
+#   ./scripts/publish-if-new.sh <crate-name>
+#
+# Exit codes:
+#   0  published OR already at workspace version (idempotent OK)
+#   N  cargo publish failed for any other reason (propagated)
+#   2  usage error (missing crate name argument)
+
+set -euo pipefail
+
+CRATE="${1:-}"
+if [[ -z "$CRATE" ]]; then
+    echo "publish-if-new: usage: $0 <crate-name>" >&2
+    exit 2
+fi
+
+# Workspace version: prefer explicit env (CI sets this) so we don't
+# have to re-parse Cargo.toml inside a runner where awk + grep can
+# get tripped by inline comments.
+if [[ -z "${WORKSPACE_VERSION:-}" ]]; then
+    SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+    REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+    WORKSPACE_VERSION="$(
+        awk '
+            /^\[workspace\.package\]/ { f=1; next }
+            f && /^\[/                 { exit }
+            f && /^version = /         {
+                gsub(/^version = "|"$/, "", $0)
+                print
+                exit
+            }
+        ' "$REPO_ROOT/Cargo.toml"
+    )"
+fi
+
+if [[ -z "$WORKSPACE_VERSION" ]]; then
+    echo "publish-if-new: ERROR — could not parse workspace version" >&2
+    exit 2
+fi
+
+# Query crates.io for the current max version of CRATE. The HTTP
+# 404 case (crate not yet published at all) returns "" → we'll
+# always publish. Any other JSON-parse failure also returns "" so
+# we err on the side of attempting the publish.
+LIVE_VERSION="$(
+    curl --silent --fail --show-error \
+        --header 'User-Agent: aegis-boot publish-if-new wrapper' \
+        "https://crates.io/api/v1/crates/${CRATE}" \
+        2>/dev/null \
+        | python3 -c 'import sys, json; d=json.load(sys.stdin); print(d.get("crate", {}).get("max_version", ""))' \
+        2>/dev/null \
+        || echo ""
+)"
+
+echo "publish-if-new: ${CRATE} — workspace=${WORKSPACE_VERSION}, live=${LIVE_VERSION:-<not on registry>}"
+
+if [[ -n "$LIVE_VERSION" && "$LIVE_VERSION" == "$WORKSPACE_VERSION" ]]; then
+    echo "publish-if-new: ${CRATE} v${WORKSPACE_VERSION} is already on crates.io — skipping (idempotent OK)."
+    exit 0
+fi
+
+echo "publish-if-new: publishing ${CRATE} v${WORKSPACE_VERSION}..."
+exec cargo publish -p "$CRATE" --locked


### PR DESCRIPTION
Mirrors the aegis-boot/aegis-boot Trusted Publishing setup so aegis-hwsim publishes to crates.io via OIDC instead of a long-lived `CARGO_REGISTRY_TOKEN`.

## What lands

- **`.github/workflows/crates-publish.yml`** (new) — tag-triggered + workflow_dispatch. Enters `release` env (tag-only deployment, no reviewer gate). OIDC-mints a ~30-min crates.io token, runs `scripts/publish-if-new.sh aegis-hwsim`.
- **`scripts/publish-if-new.sh`** (new — copied verbatim from aegis-boot) — idempotent wrapper. Skips with exit 0 if already at workspace version; real failures still fail loudly.

## Pre-staged via API (already done)

- `release` environment created on `aegis-boot/aegis-hwsim` with tag-only (`v*`) deployment policy. No reviewer required.

## Maintainer follow-up (one-time, on crates.io UI)

Verify the trusted publisher on https://crates.io/crates/aegis-hwsim/settings is set to:

| Field | Value |
|---|---|
| Repository owner | `aegis-boot` |
| Repository name | `aegis-hwsim` |
| Workflow filename | `crates-publish.yml` |
| Environment | `release` |

If you previously configured TP for `aegis-hwsim` against the OLD repo path (`williamzujkowski/aegis-hwsim`), update or re-add it under the new `aegis-boot/aegis-hwsim` path.

## Test plan

- [x] Workflow YAML validates
- [x] `release` environment exists with tag-only policy
- [ ] On next `v*.*.*` tag push: workflow runs, publishes `aegis-hwsim` (or skips cleanly if version already on crates.io)

🤖 Generated with [Claude Code](https://claude.com/claude-code)