### PR TITLE
ci: concurrency + per-job timeouts + swtpm cleanup trap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,30 @@ name: CI
 on: [push, pull_request]
 permissions:
   contents: read
+
+# Cancel superseded runs on the same ref. CLAUDE.md "Security
+# constraints #3" calls for CI concurrency limits; this prevents
+# overlapping runs from doubling up on swtpm/QEMU resource use when
+# branches are pushed in rapid succession. The `cancel-in-progress`
+# flag is safe here — tests are deterministic and a fresh run from
+# the latest commit is always preferred over an in-flight stale run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Belt + braces: any individual scenario already enforces its own
+    # in-process timeout (5 min default per CLAUDE.md), but a runaway
+    # cargo command (e.g. dependency resolution stalled on a bad
+    # mirror) would still hold the runner for GitHub's 360-min default.
+    # 30 min is well above the typical ~5 min run with headroom for
+    # cold caches.
+    timeout-minutes: 30
+    # If we ever fan this out into a matrix (E5 OS coverage, E6 TPM
+    # variants), the CLAUDE.md non-negotiable max-parallel: 4 lives
+    # here — `strategy: { matrix: ..., max-parallel: 4 }`.
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust
@@ -54,3 +75,16 @@ jobs:
           path: artifacts/coverage-grid.*
           retention-days: 30
           if-no-files-found: error
+
+      - name: Cleanup stray test processes + work dirs
+        # CLAUDE.md "Security constraints #3" mandates swtpm cleanup
+        # in trap handlers. Drop impls in src/swtpm.rs and src/serial.rs
+        # SIGKILL their children when the harness exits cleanly, but
+        # if a scenario panics the runner can leak. Belt-and-suspenders
+        # cleanup keeps the runner clean for any subsequent step and
+        # avoids leaving sockets in /tmp on shared GitHub runners.
+        if: always()
+        run: |
+          pkill -x swtpm 2>/dev/null || true
+          pkill -x qemu-system-x86_64 2>/dev/null || true
+          rm -rf /tmp/aegis-hwsim-* 2>/dev/null || true

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -37,6 +37,10 @@ jobs:
     # reviewer rule — autonomous bug-fix releases per the
     # aegis-boot/aegis-boot precedent (2026-04-22).
     environment: release
+    # Cap the whole job at 15 min. Cold OIDC + toolchain install + a
+    # crates.io publish typically takes <3 min; a 5x headroom catches
+    # crates.io stalls without sitting in the queue.
+    timeout-minutes: 15
     permissions:
       id-token: write
       contents: read
@@ -55,6 +59,11 @@ jobs:
         id: cio_auth
 
       - name: publish aegis-hwsim
+        # The publish step is the one that talks to crates.io. If the
+        # registry stalls, the whole step blocks. 10-min step cap is
+        # the explicit "give up" boundary — well above the ~30s a
+        # healthy publish takes.
+        timeout-minutes: 10
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.cio_auth.outputs.token }}
         run: ./scripts/publish-if-new.sh aegis-hwsim


### PR DESCRIPTION
## Summary

Wires the three CI requirements called out in CLAUDE.md "Security constraints #3" that weren't yet present in the workflow files.

- **Concurrency** — workflow-level `concurrency` block on `ci-${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. Prevents superseded runs piling up on rapid pushes. The non-negotiable `max-parallel: 4` is documented in a comment for the matrix scaffolding that E5/E6 will need.
- **Per-job timeouts** — `timeout-minutes: 30` on `ci.yml`'s test job; `timeout-minutes: 15` on the publish job and `timeout-minutes: 10` on the publish step in `crates-publish.yml`. Above the typical ~5 min run with cold-cache headroom; well below GitHub's 360-min default that lets a stuck step burn quota.
- **Cleanup trap** — `if: always()` step at the end of the test job that pkills any leaked `swtpm` / `qemu-system-x86_64` and `rm -rf /tmp/aegis-hwsim-*`. The `Drop` impls in `src/swtpm.rs` and `src/serial.rs` already SIGKILL their children on clean exit; this catches the panic path too and keeps shared GitHub runners clean for downstream steps.

No behavior change for green runs.

## Test plan

- [x] Workflow YAML lints clean
- [x] Run on this PR exercises the new timeout + cleanup
- [ ] Verify cleanup step runs and reports OK on the `actions/runs/...` view

🤖 Generated with [Claude Code](https://claude.com/claude-code)