### PR TITLE
feat(release): pre-publish audit refusing TEST_ONLY_NOT_FOR_PRODUCTION shipments

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -54,6 +54,22 @@ jobs:
           rustup default 1.85.0
           rustc --version
 
+      - name: Audit — refuse publish if test keyring material would ship
+        # CLAUDE.md security constraint #4: PK/KEK/db with
+        # TEST_ONLY_NOT_FOR_PRODUCTION CN must never ship to crates.io.
+        # The audit script checks two things:
+        #   1. Cargo.toml exclude list still keeps firmware/test-keyring/**
+        #      out of the package (drift detection).
+        #   2. No suspicious-extension file (.fd .pem .key .crt .der .cer
+        #      .efi .esl .auth, anything under firmware/) carries the
+        #      placeholder token.
+        # Source/doc/test-fixture references to the token are allowed
+        # (the token IS the policy enforcement constant).
+        # Runs BEFORE OIDC mint so a positive failure doesn't burn a
+        # crates.io short-lived token.
+        timeout-minutes: 2
+        run: ./scripts/audit-no-test-keys.sh
+
       - name: Mint short-lived crates.io token (OIDC)
         uses: rust-lang/crates-io-auth-action@v1
         id: cio_auth

--- a/scripts/audit-no-test-keys.sh
+++ b/scripts/audit-no-test-keys.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# audit-no-test-keys.sh — release-gate audit refusing publish if any
+# `TEST_ONLY_NOT_FOR_PRODUCTION` keyring material would ship to crates.io.
+#
+# Why a script (not build.rs):
+#   build.rs runs on every `cargo build`/`cargo test` — wrong layer for
+#   a release-time guard. It would also fight with local development
+#   (a contributor with a generated test keyring under firmware/ would
+#   see their builds fail). This script runs at the publish boundary,
+#   exactly where the security constraint matters.
+#
+# Per CLAUDE.md "Security constraints #4" + aegis-hwsim epic E5 (#5):
+#   "Test Secure Boot keys — PK/KEK/db MUST carry
+#    `TEST_ONLY_NOT_FOR_PRODUCTION` in CN. Generated on first run.
+#    Never ship in published artifacts."
+#
+# This audit verifies BOTH halves of the contract:
+#   1. Cargo.toml's `exclude` list still keeps firmware/test-keyring/**
+#      out of the cargo package. (Drift detection.)
+#   2. No file inside the would-be-published artifact contains the
+#      `TEST_ONLY_NOT_FOR_PRODUCTION` token. (Defense in depth — catches
+#      a forgotten test fixture or copy-pasted CN that snuck out of the
+#      excluded directory.)
+#
+# Usage:
+#   ./scripts/audit-no-test-keys.sh [package-list-file]
+#
+#   With no argument, runs `cargo package --list --allow-dirty` and
+#   audits the resulting file list. With an argument, treats the file
+#   as a pre-computed `cargo package --list` output (one path per line).
+#
+# Exit codes:
+#   0  no forbidden material would publish
+#   1  forbidden material detected — refuses publish
+#   2  audit failed to run (cargo missing, etc.)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+FORBIDDEN_TOKEN="TEST_ONLY_NOT_FOR_PRODUCTION"
+EXCLUDED_DIR_PREFIX="firmware/test-keyring/"
+
+# 1) Enumerate the file list cargo would publish.
+PACKAGE_LIST="${1:-}"
+if [[ -z "$PACKAGE_LIST" ]]; then
+    if ! command -v cargo >/dev/null 2>&1; then
+        echo "audit-no-test-keys: ERROR — cargo not on PATH" >&2
+        exit 2
+    fi
+    # `--allow-dirty` lets the audit run on uncommitted CI checkouts.
+    # `--list` prints the file paths cargo would tar; no actual archive
+    # is produced. `cargo package --list` exits 0 even on clean repos
+    # and emits one path per line relative to crate root.
+    PACKAGE_LIST_TMP="$(mktemp)"
+    trap 'rm -f "$PACKAGE_LIST_TMP"' EXIT
+    if ! cargo package --list --allow-dirty >"$PACKAGE_LIST_TMP" 2>/dev/null; then
+        echo "audit-no-test-keys: ERROR — \`cargo package --list\` failed" >&2
+        exit 2
+    fi
+    PACKAGE_LIST="$PACKAGE_LIST_TMP"
+fi
+
+if [[ ! -r "$PACKAGE_LIST" ]]; then
+    echo "audit-no-test-keys: ERROR — package list not readable: $PACKAGE_LIST" >&2
+    exit 2
+fi
+
+# 2) Drift check: no path under the excluded directory should appear.
+EXCLUDED_HITS="$(grep -E "^${EXCLUDED_DIR_PREFIX}" "$PACKAGE_LIST" || true)"
+if [[ -n "$EXCLUDED_HITS" ]]; then
+    echo "audit-no-test-keys: FAIL — Cargo.toml exclude list drift" >&2
+    echo "" >&2
+    echo "The following files under '${EXCLUDED_DIR_PREFIX}' are about to" >&2
+    echo "be packaged. They must stay excluded — they're test keyring" >&2
+    echo "material with TEST_ONLY_NOT_FOR_PRODUCTION CNs." >&2
+    echo "" >&2
+    echo "$EXCLUDED_HITS" >&2
+    echo "" >&2
+    echo "Fix: re-check Cargo.toml [package].exclude includes" >&2
+    echo "     'firmware/test-keyring/**' (and rebuild Cargo.lock if needed)." >&2
+    exit 1
+fi
+
+# 3) Token sweep: scan suspicious-extension files in the package list
+#    for the placeholder marker. Catches a leaked cert, a generated
+#    keyring blob, or a UEFI VARS fixture that escaped the excluded
+#    directory.
+#
+#    Scope is deliberately narrow — we DON'T audit every .rs, .md, .yaml,
+#    or .json file because the token legitimately appears in:
+#    * src/loader.rs (defines the PLACEHOLDER_TOKEN constant — the
+#      string IS the policy)
+#    * src/persona.rs + schemas/persona.schema.json (docstrings
+#      explaining the security constraint)
+#    * tests/fixtures/bad-placeholder-token.yaml (negative test
+#      that deliberately includes the token)
+#
+#    The risk this audit guards against is binary key material with
+#    a `TEST_ONLY_NOT_FOR_PRODUCTION` CN slipping into the package —
+#    that's `.fd` / `.pem` / `.key` / `.crt` / `.der` / `.cer` / `.efi`
+#    / `.esl` files plus anything under firmware/ regardless of
+#    extension. We sweep that subset for the token.
+#
+#    `grep -l` (well, `quiet --fixed-strings`) reports presence, not
+#    contents, so we don't accidentally dump secrets into CI logs.
+suspicious_path() {
+    local path="$1"
+    case "$path" in
+        firmware/*) return 0 ;;
+        *.fd|*.pem|*.key|*.crt|*.der|*.cer|*.efi|*.esl|*.auth) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+TOKEN_HITS=()
+while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    [[ ! -f "$path" ]] && continue
+    if ! suspicious_path "$path"; then
+        continue
+    fi
+    if grep --binary-files=text --quiet --fixed-strings -- "$FORBIDDEN_TOKEN" "$path"; then
+        TOKEN_HITS+=("$path")
+    fi
+done < "$PACKAGE_LIST"
+
+if [[ ${#TOKEN_HITS[@]} -gt 0 ]]; then
+    echo "audit-no-test-keys: FAIL — TEST_ONLY_NOT_FOR_PRODUCTION token in package" >&2
+    echo "" >&2
+    echo "The following files would publish to crates.io with the test-only" >&2
+    echo "marker token in them. This violates CLAUDE.md security constraint" >&2
+    echo "#4 — test keyring material must never ship." >&2
+    echo "" >&2
+    for f in "${TOKEN_HITS[@]}"; do
+        echo "  - $f" >&2
+    done
+    echo "" >&2
+    echo "Fix: either remove the test material from these files, or add" >&2
+    echo "     them to Cargo.toml [package].exclude." >&2
+    exit 1
+fi
+
+echo "audit-no-test-keys: PASS — no test keyring material in cargo package"
+exit 0


### PR DESCRIPTION
## Summary

CLAUDE.md security constraint #4 says PK/KEK/db keys with the `TEST_ONLY_NOT_FOR_PRODUCTION` CN must **never** ship to crates.io. Until now the only enforcement was the `Cargo.toml` `exclude` list — fragile, since a contributor moving the keyring directory could silently regress it.

`scripts/audit-no-test-keys.sh` adds release-time enforcement with two checks:

1. **Drift check** — greps `cargo package --list --allow-dirty` for anything under `firmware/test-keyring/`. Catches `Cargo.toml` exclude-list regressions.
2. **Token sweep** — scans suspicious-extension files (`.fd .pem .key .crt .der .cer .efi .esl .auth`, plus anything under `firmware/`) for the placeholder token. **Source, docs, schema, and test-fixture references to the token are allowed** because the token IS the policy enforcement constant (defined in `src/loader.rs` as `PLACEHOLDER_TOKEN`).

The audit runs as a separate step in `crates-publish.yml` BEFORE the OIDC token mint — a positive failure doesn't burn a crates.io short-lived token.

## Why a script (not build.rs)

The Contrarian vote on the E5 consensus specifically called out putting this in `build.rs` as a Cargo anti-pattern: `build.rs` runs on every `cargo build`/`cargo test` and would fight with local development (a contributor with a generated test keyring would see their builds fail). This script runs at the publish boundary, exactly where the constraint matters.

## Smoke tests

\`\`\`
$ ./scripts/audit-no-test-keys.sh
audit-no-test-keys: PASS — no test keyring material in cargo package
exit=0

$ # Synthetic fake.fd containing the token:
$ printf 'TEST_ONLY_NOT_FOR_PRODUCTION\n' > /tmp/fake.fd
$ echo /tmp/fake.fd > /tmp/list.txt && ./scripts/audit-no-test-keys.sh /tmp/list.txt
audit-no-test-keys: FAIL — TEST_ONLY_NOT_FOR_PRODUCTION token in package
  - /tmp/fake.fd
exit=1
\`\`\`

## Test plan

- [x] PASS run on the current tree (token references in `src/loader.rs`, `src/persona.rs`, `tests/fixtures/bad-placeholder-token.yaml`, `schemas/persona.schema.json` are all correctly allowlisted).
- [x] FAIL run with a synthetic suspicious file — error message names the offending path.
- [x] \`bash -n\` syntax check clean.
- [ ] CI green (this PR's CI doesn't run the audit — only tag pushes do — but the script structure is verified by the bash syntax check).

Refs #5, #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)