### PR TITLE
ci(codeql): add CodeQL workflow for Rust static analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,86 @@
+name: CodeQL
+# Static-analysis scanning via GitHub CodeQL. Rust support graduated to
+# generally-available in mid-2025; we run it here so the harness gets
+# the same security-finding surface as the rest of the aegis-boot
+# family. Findings appear in the repo's Security tab.
+#
+# Triggers:
+#   - push to main (so post-merge wins/regressions show up)
+#   - pull_request targeting main (so PRs preview their findings)
+#   - weekly schedule (so a new CodeQL query release lights up
+#     pre-existing-but-undetected issues without waiting for a push)
+#
+# Per CLAUDE.md "Security constraints", this complements but doesn't
+# replace:
+#   - cargo clippy + cargo fmt (style + obvious correctness)
+#   - tests/fuzz_invocation.rs (40k adversarial argv inputs/run)
+#   - scripts/audit-no-test-keys.sh (release-gate marker sweep)
+# CodeQL adds taint-flow analysis: tracks data from sources (env,
+# argv, file I/O) to sinks (Command::new, fs ops) and flags any
+# unvalidated reach.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays 06:13 UTC — off-peak, avoids contention with other
+    # repo's nightly runs. The minute is jittered (not :00) so
+    # GitHub doesn't pile a thundering-herd on the hour boundary.
+    - cron: '13 6 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL — Rust
+    runs-on: ubuntu-latest
+    # CodeQL on a small Rust crate is typically <5 min; 30 min cap
+    # gives headroom for cold-cache toolchain installs and a future
+    # matrix expansion (e.g. add C/C++ when we ship vendored OVMF).
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [rust]
+      # If the matrix grows (rust + python for scripts/, etc.), the
+      # CLAUDE.md non-negotiable max-parallel: 4 lives here.
+      # max-parallel: 4
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain (pinned to MSRV)
+        # CodeQL needs cargo+rustc available to autobuild. Pin to the
+        # same MSRV as ci.yml so analysis runs against the version
+        # the project actually ships against.
+        run: |
+          rustup toolchain install 1.85.0 --profile minimal
+          rustup default 1.85.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended is the full CodeQL query suite; the
+          # default 'security-and-quality' adds maintainability lints
+          # which mostly duplicate clippy. We want the security delta.
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

CodeQL Rust support graduated to GA in mid-2025; this wires up the analyze pipeline the aegis-boot family uses. Findings land in the repo's Security tab.

## What it adds vs existing CI gates

- `cargo clippy` / `cargo fmt` — style + obvious correctness
- `tests/fuzz_invocation.rs` — 40k adversarial argv inputs/run
- `scripts/audit-no-test-keys.sh` — release-gate marker sweep
- **NEW: CodeQL** — taint-flow analysis. Tracks data from sources (env, argv, file I/O) to sinks (`Command::new`, `fs` ops) and flags any unvalidated reach.

## Triggers

- `push` to `main` — post-merge regressions
- `pull_request` targeting `main` — preview findings before merge
- `schedule` (weekly, Monday 06:13 UTC) — new query releases against existing code

## Workflow shape

Mirrors PR-B's patterns:

- workflow-level `concurrency:` block keyed on workflow + ref, `cancel-in-progress: true`
- job-level `timeout-minutes: 30` (CodeQL on a small Rust crate is typically <5 min; 30 min covers cold-cache + future matrix expansion)
- `max-parallel: 4` placeholder comment for matrix growth (e.g. add C/C++ when we ship vendored OVMF)

## Configuration choices

- `queries: security-extended` — full security delta. Default `security-and-quality` adds maintainability lints which mostly duplicate clippy.
- Rust toolchain pinned to MSRV 1.85.0 (matches `ci.yml`) so analysis runs against the version the project actually ships against.
- `actions/checkout@v5` + `github/codeql-action/{init,autobuild,analyze}@v3` — major-version tags. SHA-pinning is on the v1.0 hardening list but not mandated by CLAUDE.md yet.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` clean
- [ ] CI run on this PR exercises the new workflow (first CodeQL run will populate the Security tab)

Refs the user's "codeql findings" follow-up; closes the static-analysis gap on the v1.0 readiness checklist (#7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)