### PR TITLE
refactor(hygiene): code-review followups — json::escape + HashMap render + io::Error display

### DIFF
--- a/src/bin/aegis-hwsim.rs
+++ b/src/bin/aegis-hwsim.rs
@@ -206,11 +206,14 @@ fn print_list_json(personas: &[Persona]) {
     for (i, p) in personas.iter().enumerate() {
         let comma = if i == last { "" } else { "," };
         println!("    {{");
-        println!("      \"id\": \"{}\",", json_escape(&p.id));
-        println!("      \"vendor\": \"{}\",", json_escape(&p.vendor));
+        println!("      \"id\": \"{}\",", aegis_hwsim::json::escape(&p.id));
+        println!(
+            "      \"vendor\": \"{}\",",
+            aegis_hwsim::json::escape(&p.vendor)
+        );
         println!(
             "      \"display_name\": \"{}\",",
-            json_escape(&p.display_name)
+            aegis_hwsim::json::escape(&p.display_name)
         );
         println!(
             "      \"source_kind\": \"{}\",",
@@ -263,29 +266,6 @@ fn truncate(s: &str, max: usize) -> String {
     }
     let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
     out.push('\u{2026}');
-    out
-}
-
-/// Minimal JSON string escaper — covers `"`, `\`, control chars, newline,
-/// tab. Not a general-purpose JSON library; we keep the output format
-/// deterministic + dependency-light (matches aegis-boot's
-/// `doctor::json_escape` shape so the family parses uniformly).
-fn json_escape(s: &str) -> String {
-    use std::fmt::Write as _;
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if (c as u32) < 0x20 => {
-                let _ = write!(out, "\\u{:04x}", c as u32);
-            }
-            c => out.push(c),
-        }
-    }
     out
 }
 
@@ -478,8 +458,11 @@ fn print_scenarios_json(registry: &aegis_hwsim::scenario::Registry) {
     for (i, (name, desc)) in entries.iter().enumerate() {
         let comma = if i == last { "" } else { "," };
         println!("    {{");
-        println!("      \"name\": \"{}\",", json_escape(name));
-        println!("      \"description\": \"{}\"", json_escape(desc));
+        println!("      \"name\": \"{}\",", aegis_hwsim::json::escape(name));
+        println!(
+            "      \"description\": \"{}\"",
+            aegis_hwsim::json::escape(desc)
+        );
         println!("    }}{comma}");
     }
     println!("  ]");

--- a/src/coverage_grid.rs
+++ b/src/coverage_grid.rs
@@ -22,6 +22,7 @@
 
 use crate::persona::Persona;
 use crate::scenario::{Registry, Scenario, ScenarioContext, ScenarioError, ScenarioResult};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -199,18 +200,18 @@ fn render_json(cells: &[GridCell]) -> String {
         let _ = writeln!(
             out,
             "      \"persona_id\": \"{}\",",
-            json_escape(&c.persona_id)
+            crate::json::escape(&c.persona_id)
         );
         let _ = writeln!(
             out,
             "      \"scenario_name\": \"{}\",",
-            json_escape(c.scenario_name)
+            crate::json::escape(c.scenario_name)
         );
         let _ = writeln!(out, "      \"result\": \"{}\",", c.outcome.label());
         let _ = writeln!(
             out,
             "      \"reason\": \"{}\",",
-            json_escape(c.outcome.reason())
+            crate::json::escape(c.outcome.reason())
         );
         let _ = writeln!(out, "      \"duration_ms\": {}", c.duration.as_millis());
         let _ = writeln!(out, "    }}{comma}");
@@ -226,6 +227,17 @@ fn render_markdown(cells: &[GridCell], registry: &Registry) -> String {
     let mut personas: Vec<String> = cells.iter().map(|c| c.persona_id.clone()).collect();
     personas.sort();
     personas.dedup();
+
+    // Build a (persona, scenario) → label index once. The previous
+    // version did `cells.iter().find(...)` per cell-render iteration —
+    // O(personas × scenarios × cells) ≈ O(N²·M²) for N personas and
+    // M scenarios. With 11 personas × 4 scenarios that's 1936 ops on
+    // the current grid; harmless today but the math gets cubic-ish
+    // as the grid grows. HashMap lookup keeps the render in O(N·M).
+    let mut index: HashMap<(&str, &str), &'static str> = HashMap::with_capacity(cells.len());
+    for c in cells {
+        index.insert((&c.persona_id, c.scenario_name), c.outcome.label());
+    }
 
     let mut out = String::with_capacity(cells.len() * 80);
     out.push_str("# aegis-hwsim coverage grid\n\n");
@@ -252,10 +264,7 @@ fn render_markdown(cells: &[GridCell], registry: &Registry) -> String {
     for p in &personas {
         let _ = write!(out, "| {p} |");
         for s in &scenarios {
-            let cell = cells
-                .iter()
-                .find(|c| c.persona_id == *p && c.scenario_name == *s);
-            let label = cell.map_or("?", |c| c.outcome.label());
+            let label = index.get(&(p.as_str(), *s)).copied().unwrap_or("?");
             let _ = write!(out, " {label} |");
         }
         out.push('\n');
@@ -277,28 +286,6 @@ fn render_markdown(cells: &[GridCell], registry: &Registry) -> String {
             c.outcome.label(),
             r
         );
-    }
-    out
-}
-
-/// Minimal JSON string escape — covers `"`, `\`, control chars, newline,
-/// tab. Matches the existing pattern in `aegis-hwsim list-personas
-/// --json` so the family parses uniformly.
-fn json_escape(s: &str) -> String {
-    use std::fmt::Write as _;
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if (c as u32) < 0x20 => {
-                let _ = write!(out, "\\u{:04x}", c as u32);
-            }
-            c => out.push(c),
-        }
     }
     out
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -132,7 +132,7 @@ impl Report {
         let _ = writeln!(
             out,
             "  \"next_action\": \"{}\",",
-            json_escape(&self.next_action())
+            crate::json::escape(&self.next_action())
         );
         let _ = writeln!(out, "  \"has_failures\": {},", self.has_failures());
         let _ = writeln!(out, "  \"has_warnings\": {},", self.has_warnings());
@@ -142,37 +142,22 @@ impl Report {
             let comma = if i == last { "" } else { "," };
             out.push_str("    {\n");
             let _ = writeln!(out, "      \"verdict\": \"{}\",", c.verdict.label());
-            let _ = writeln!(out, "      \"subject\": \"{}\",", json_escape(&c.subject));
-            let _ = writeln!(out, "      \"message\": \"{}\"", json_escape(&c.message));
+            let _ = writeln!(
+                out,
+                "      \"subject\": \"{}\",",
+                crate::json::escape(&c.subject)
+            );
+            let _ = writeln!(
+                out,
+                "      \"message\": \"{}\"",
+                crate::json::escape(&c.message)
+            );
             let _ = writeln!(out, "    }}{comma}");
         }
         out.push_str("  ]\n");
         out.push_str("}\n");
         out
     }
-}
-
-/// Minimal JSON string escape — matches the helper in
-/// `bin/aegis-hwsim.rs` + `coverage_grid.rs`. Duplicated here only
-/// because doctor doesn't depend on either; would extract to a shared
-/// `json` module if a fourth caller appeared.
-fn json_escape(s: &str) -> String {
-    use std::fmt::Write as _;
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if (c as u32) < 0x20 => {
-                let _ = write!(out, "\\u{:04x}", c as u32);
-            }
-            c => out.push(c),
-        }
-    }
-    out
 }
 
 /// Run the doctor checks against `firmware_root`. Returns a [`Report`]
@@ -298,18 +283,31 @@ fn check_personas_dir(personas_dir: &Path) -> Check {
             ),
         };
     }
-    let count = std::fs::read_dir(personas_dir)
-        .map(|iter| {
-            iter.flatten()
-                .filter(|e| {
-                    e.path()
-                        .extension()
-                        .and_then(|s| s.to_str())
-                        .is_some_and(|s| s == "yaml")
-                })
-                .count()
+    // Surface read_dir errors as a Fail with the underlying message
+    // rather than silently treating them as "0 yaml files". An
+    // unreadable persona dir (permissions, disk error, FUSE drop) is
+    // a configuration problem the operator needs to know about — the
+    // previous `unwrap_or(0)` rendered it indistinguishable from
+    // "directory exists but empty" which is the wrong diagnostic.
+    let iter = match std::fs::read_dir(personas_dir) {
+        Ok(it) => it,
+        Err(e) => {
+            return Check {
+                verdict: Verdict::Fail,
+                subject: "personas/".into(),
+                message: format!("cannot read directory {}: {e}", personas_dir.display()),
+            };
+        }
+    };
+    let count = iter
+        .flatten()
+        .filter(|e| {
+            e.path()
+                .extension()
+                .and_then(|s| s.to_str())
+                .is_some_and(|s| s == "yaml")
         })
-        .unwrap_or(0);
+        .count();
     if count == 0 {
         return Check {
             verdict: Verdict::Fail,

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,112 @@
+//! Minimal JSON string escaper, shared across the modules that emit
+//! `schema_version=1` JSON envelopes (`bin/aegis-hwsim`, `coverage_grid`,
+//! `doctor`).
+//!
+//! Why a hand-rolled escaper rather than `serde_json` for everything:
+//! the JSON output we produce is small, fixed-shape, and built by
+//! formatting whole-document templates rather than driving serde's
+//! `Serializer`. Pulling `serde_json::to_string_pretty` for one-line
+//! string escapes adds an allocation + a serializer instantiation per
+//! escape; the hand-rolled version is a single pass over the input.
+//!
+//! The function is deliberately conservative: it escapes the JSON
+//! grammar's mandatory escapes (`"`, `\`), the four common
+//! whitespace-control chars (`\n`, `\r`, `\t`, plus the implicit
+//! sub-`0x20` `\uXXXX` form), and nothing else. UTF-8 is passed through
+//! verbatim — same shape `serde_json` produces by default.
+//!
+//! Until #58 there were three near-identical copies of this function;
+//! a comment in `doctor.rs` documented the policy as "extract on the
+//! fourth caller". The fourth caller (`test_keyring`'s README emitter)
+//! never quite happened, but the duplication was already a hygiene
+//! debt the code review flagged. This module closes it.
+
+/// Escape `s` for inclusion as a JSON string body (no surrounding quotes).
+///
+/// Escapes:
+/// - `"`  → `\"`
+/// - `\`  → `\\`
+/// - `\n` → `\n`
+/// - `\r` → `\r`
+/// - `\t` → `\t`
+/// - any other control char (`< 0x20`) → `\u00XX`
+///
+/// All other characters (including non-ASCII UTF-8) pass through unchanged.
+#[must_use]
+pub fn escape(s: &str) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_passes_ascii_unchanged() {
+        assert_eq!(escape("hello world"), "hello world");
+        assert_eq!(escape(""), "");
+    }
+
+    #[test]
+    fn escape_doubles_backslash() {
+        assert_eq!(escape(r"path\to\file"), r"path\\to\\file");
+    }
+
+    #[test]
+    fn escape_escapes_double_quote() {
+        assert_eq!(escape("say \"hi\""), "say \\\"hi\\\"");
+    }
+
+    #[test]
+    fn escape_handles_common_whitespace_controls() {
+        assert_eq!(escape("a\nb"), "a\\nb");
+        assert_eq!(escape("a\rb"), "a\\rb");
+        assert_eq!(escape("a\tb"), "a\\tb");
+    }
+
+    #[test]
+    fn escape_emits_uxxxx_for_other_control_chars() {
+        // 0x01 (SOH), 0x07 (BEL), 0x1f (US): all get \u00XX form.
+        assert_eq!(escape("\x01"), "\\u0001");
+        assert_eq!(escape("\x07"), "\\u0007");
+        assert_eq!(escape("\x1f"), "\\u001f");
+    }
+
+    #[test]
+    fn escape_passes_non_ascii_utf8_unchanged() {
+        // Greek + Chinese + emoji — all pass through as raw UTF-8,
+        // matching serde_json's default (it doesn't \uXXXX-escape
+        // BMP/non-BMP unless asked).
+        assert_eq!(escape("ναί"), "ναί");
+        assert_eq!(escape("好"), "好");
+        assert_eq!(escape("🦀"), "🦀");
+    }
+
+    #[test]
+    fn escape_output_round_trips_through_serde_json() {
+        // The whole point of this function is to produce something
+        // that can be wrapped in `"..."` and parsed as valid JSON.
+        // Round-trip a torture string through serde_json::from_str
+        // to confirm the escape contract holds.
+        let input = "quote\" backslash\\ newline\n tab\t ctrl\x01 utf8\u{1F980} end";
+        let json_body = format!("\"{}\"", escape(input));
+        let parsed: String = serde_json::from_str(&json_body).expect("must parse");
+        assert_eq!(parsed, input);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod coverage_grid;
 pub mod doctor;
+pub mod json;
 pub mod loader;
 pub mod ovmf;
 pub mod persona;

--- a/src/ovmf.rs
+++ b/src/ovmf.rs
@@ -220,7 +220,7 @@ fn verify_keyring_under_root(keyring: &Path, firmware_root: &Path) -> Result<Pat
 fn canonicalize_or_err(path: &Path) -> Result<PathBuf, OvmfError> {
     std::fs::canonicalize(path).map_err(|e| OvmfError::Canonicalize {
         path: path.to_path_buf(),
-        kind: format!("{:?}", e.kind()),
+        kind: e.to_string(),
     })
 }
 

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -81,7 +81,7 @@ impl Invocation {
         }
         let stick_canon = fs::canonicalize(stick).map_err(|e| InvocationError::StickNotFound {
             path: stick.to_path_buf(),
-            kind: format!("{:?}", e.kind()),
+            kind: e.to_string(),
         })?;
 
         // Resolve `OVMF_CODE` + VARS template (the CustomPk keyring check
@@ -101,19 +101,19 @@ impl Invocation {
         // and re-check `starts_with`.
         fs::create_dir_all(work_dir).map_err(|e| InvocationError::WorkDirInaccessible {
             path: work_dir.to_path_buf(),
-            kind: format!("{:?}", e.kind()),
+            kind: e.to_string(),
         })?;
         let work_root_canon =
             fs::canonicalize(work_dir).map_err(|e| InvocationError::WorkDirInaccessible {
                 path: work_dir.to_path_buf(),
-                kind: format!("{:?}", e.kind()),
+                kind: e.to_string(),
             })?;
         let vars_copy = work_root_canon.join("OVMF_VARS.fd");
         fs::copy(&paths.vars_template, &vars_copy).map_err(|e| {
             InvocationError::VarsCopyFailed {
                 from: paths.vars_template.clone(),
                 to: vars_copy.clone(),
-                kind: format!("{:?}", e.kind()),
+                kind: e.to_string(),
             }
         })?;
 
@@ -126,7 +126,7 @@ impl Invocation {
             fs::canonicalize(&vars_copy).map_err(|e| InvocationError::VarsCopyFailed {
                 from: paths.vars_template.clone(),
                 to: vars_copy.clone(),
-                kind: format!("{:?}", e.kind()),
+                kind: e.to_string(),
             })?;
         if !vars_copy_canon.starts_with(&work_root_canon) {
             return Err(InvocationError::VarsCopyEscapedRoot {
@@ -263,7 +263,10 @@ pub enum InvocationError {
     StickNotFound {
         /// The path the operator passed.
         path: PathBuf,
-        /// Rendered `io::ErrorKind`.
+        /// Underlying `io::Error` message — Display form so OS-level
+        /// detail (e.g. "No such file or directory (os error 2)")
+        /// surfaces to the operator instead of the bare `ErrorKind`
+        /// name.
         kind: String,
     },
 
@@ -281,7 +284,10 @@ pub enum InvocationError {
     WorkDirInaccessible {
         /// The path that couldn't be created.
         path: PathBuf,
-        /// Rendered `io::ErrorKind`.
+        /// Underlying `io::Error` message — Display form so OS-level
+        /// detail (e.g. "No such file or directory (os error 2)")
+        /// surfaces to the operator instead of the bare `ErrorKind`
+        /// name.
         kind: String,
     },
 
@@ -292,7 +298,10 @@ pub enum InvocationError {
         from: PathBuf,
         /// Destination per-run copy.
         to: PathBuf,
-        /// Rendered `io::ErrorKind`.
+        /// Underlying `io::Error` message — Display form so OS-level
+        /// detail (e.g. "No such file or directory (os error 2)")
+        /// surfaces to the operator instead of the bare `ErrorKind`
+        /// name.
         kind: String,
     },
 

--- a/src/swtpm.rs
+++ b/src/swtpm.rs
@@ -109,7 +109,7 @@ impl SwtpmInstance {
         }
         fs::create_dir_all(&spec.state_dir).map_err(|e| SwtpmError::WorkDirInaccessible {
             path: spec.state_dir.clone(),
-            kind: format!("{:?}", e.kind()),
+            kind: e.to_string(),
         })?;
 
         let mut cmd = Command::new(binary);
@@ -134,7 +134,7 @@ impl SwtpmInstance {
 
         let child = cmd.spawn().map_err(|e| SwtpmError::SpawnFailed {
             binary: binary.to_string(),
-            kind: format!("{:?}", e.kind()),
+            kind: e.to_string(),
         })?;
 
         Ok(Self::Live {
@@ -191,7 +191,10 @@ pub enum SwtpmError {
     WorkDirInaccessible {
         /// The state dir path we tried to create.
         path: PathBuf,
-        /// Rendered `io::ErrorKind`.
+        /// Underlying `io::Error` message — Display form so OS-level
+        /// detail (e.g. "No such file or directory (os error 2)")
+        /// surfaces to the operator instead of the bare `ErrorKind`
+        /// name.
         kind: String,
     },
 
@@ -201,7 +204,10 @@ pub enum SwtpmError {
     SpawnFailed {
         /// Binary name that failed.
         binary: String,
-        /// Rendered `io::ErrorKind`.
+        /// Underlying `io::Error` message — Display form so OS-level
+        /// detail (e.g. "No such file or directory (os error 2)")
+        /// surfaces to the operator instead of the bare `ErrorKind`
+        /// name.
         kind: String,
     },
 }


### PR DESCRIPTION
## Summary

Folds the four leftover items from the post-Phase-2 code review.

| Bucket | What | Why |
|---|---|---|
| **L2** | `json_escape` duplicated 3× → extracted to `src/json.rs` | The duplication was already commented as "extract on the fourth caller"; closing the debt before the fourth caller arrives. |
| **M5** | `coverage_grid::render_markdown` O(N²·M²) → O(N·M) via HashMap | `cells.iter().find(...)` per cell-render iteration. Harmless today (11 × 4 = 44 cells, 1936 ops); cubic-ish as the grid grows. |
| **M6** | `doctor::check_personas_dir`'s `read_dir` errors silently mapped to "0 files" → surface the `io::Error` | Previously, "directory unreadable" was indistinguishable from "directory empty". Now operators see the actual permissions/EIO/FUSE diagnostic in the FAIL message. |
| **L1** | `format!("{:?}", e.kind())` in qemu/swtpm/ovmf → `e.to_string()` | `NotFound` becomes `No such file or directory (os error 2)`. The `kind: String` field name stays for source compat; the docstring updates describe the new Display contract. |

## What's in `src/json.rs`

A single 17-line `escape(s: &str) -> String` function with 7 unit tests covering:

- ASCII passthrough
- Backslash + double-quote escaping (the JSON-mandatory pair)
- Common whitespace controls (`\n`, `\r`, `\t`)
- Sub-`0x20` control-char `\u00XX` form
- UTF-8 (Greek + CJK + emoji) passthrough
- Round-trip through `serde_json::from_str` (the most important: confirms anything we output can be wrapped in quotes and parsed back)

The three callers (`bin/aegis-hwsim.rs`, `src/coverage_grid.rs`, `src/doctor.rs`) now delegate to `crate::json::escape`. Behavior is byte-identical; the change is purely structural.

## What I deliberately did **not** change

- **`kind` field name** stays. Renaming would be a public-API breaking change (these errors are part of `pub enum InvocationError`). Just the docstring updates.
- **L3 (parameterize the 6 fuzz tests)** — left as future cleanup. The tests are independently readable, the duplication is contained, and parameterizing them would push real complexity (macro definition or test-data slice) for a small win. Not worth the readability cost in the same PR as the L1/L2/M5/M6 work.
- **L5 (SHA-pin actions)** — separate concern; tracked as a v1.0 hardening item.

## Test plan

- [x] `cargo +1.85.0 fmt --check` clean
- [x] `cargo +1.85.0 clippy --all-targets -- -D warnings` clean
- [x] `cargo +1.85.0 test` — 122 lib tests pass (was 115; +7 new from `src/json.rs` tests, no test removals)
- [x] All integration tests + 10 fuzz + 5 negative_fixtures + 1 schema_roundtrip pass
- [x] `cargo run -- list-personas --json | jq` round-trips clean
- [x] `cargo run -- doctor --json | jq '.checks | length'` returns 11
- [x] `cargo run -- gen-schema --check` clean
- [x] `cargo +1.85.0 publish --dry-run --allow-dirty` clean (verifies the audit + dry-run gate from PR-N still passes after these refactors)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)