### PR TITLE
feat(scenarios): tighten TEST_LANDMARKS to aegis-boot rescue-tui contract

### DIFF
--- a/src/scenarios/kexec_refuses_unsigned.rs
+++ b/src/scenarios/kexec_refuses_unsigned.rs
@@ -1,43 +1,26 @@
-//! `kexec-refuses-unsigned` — under enforcing Secure Boot + kernel lockdown, a `kexec_file_load` of an unsigned kernel must be rejected with `EKEYREJECTED` (errno 129); aegis-boot's rescue-tui then surfaces the specific diagnostic.
+//! `kexec-refuses-unsigned` — under enforcing Secure Boot + kernel lockdown, a `kexec_file_load` of an unsigned kernel must be rejected; aegis-boot's rescue-tui surfaces a `REJECTED (errno: ...)` landmark for any of the legitimate kernel-rejection paths (`EKEYREJECTED`, `EPERM-lockdown`, or `other:`).
 //!
 //! # What this scenario asserts
 //!
-//! 1. Persona boots successfully (shim → grub → kernel → rescue-tui),
-//!    same path as [`super::SignedBootUbuntu`].
-//! 2. Rescue-tui's kexec-test mode runs (triggered by the stick's
-//!    initramfs detecting a `aegis.test=kexec-unsigned` kernel
-//!    cmdline parameter, or the operator typing `kexec-test unsigned`
-//!    at the rescue-tui prompt — both surface the same diagnostic).
-//! 3. The kernel rejects the unsigned kexec; serial captures
-//!    `kexec_file_load` returning `EKEYREJECTED` (errno 129) — the
-//!    actual errno the lockdown / IMA enforcement raises (the issue
-//!    body referenced "errno 61" but kernel source
-//!    `kernel/kexec_file.c` calls `-EKEYREJECTED`; the exact match
-//!    is verified against aegis-boot upstream).
-//! 4. Rescue-tui prints a recognizable operator-facing diagnostic
-//!    referencing the rejection — that's the user-visible payoff of
-//!    the test, distinct from the raw kernel errno.
+//! 1. Persona boots successfully (shim → grub → kernel → init), same prerequisite chain as [`super::SignedBootUbuntu`].
+//! 2. The initramfs detects `aegis.test=kexec-unsigned` on the kernel cmdline and exports `AEGIS_TEST=kexec-unsigned`. `init` prints `init: AEGIS_TEST=kexec-unsigned (cmdline-driven test mode)` per [aegis-boot `scripts/build-initramfs.sh`](https://github.com/aegis-boot/aegis-boot/pull/680).
+//! 3. Rescue-tui's `dispatch_from_env` fires the `kexec-unsigned` test mode (short-circuiting the interactive TUI), prints `aegis-boot-test: kexec-unsigned starting`, attempts `kexec_file_load(2)` against an obviously-unsigned 4 KiB blob, and prints one of the `REJECTED (errno: ...)` landmarks — the operator-facing payoff that distinguishes "kernel rejected the load" from random unrelated errno output.
+//! 4. The substring contract is published in [aegis-boot `docs/rescue-tui-serial-format.md`](https://github.com/aegis-boot/aegis-boot/blob/main/docs/rescue-tui-serial-format.md): "additional tokens may be appended (e.g. wrap a numeric errno value), but the head string up through the first parenthesis stays identical across releases." So matching `aegis-boot-test: kexec-unsigned REJECTED` covers all three Pass forms.
 //!
 //! # Prerequisites
 //!
-//! - An aegis-boot stick built with the `kexec-test` initramfs hook
-//!   AND the rescue-tui's diagnostic code wired up. A stick that
-//!   boots cleanly to the rescue menu (no test mode) will Skip here
-//!   rather than Fail — the test isn't measuring anything in that
-//!   configuration.
-//! - Persona with `secure_boot.ovmf_variant: ms_enrolled` (or
-//!   `custom_pk` once E5.1d/E5.1b are in routine use). `disabled`
-//!   and `setup_mode` skip — without enforcement, kexec will
-//!   succeed and the scenario can't measure rejection.
+//! - An aegis-boot stick whose grub.cfg adds `aegis.test=kexec-unsigned` to the kernel cmdline (or one where the operator types it at GRUB's `e` edit prompt). A stick that boots cleanly to the rescue menu without the cmdline will Skip — the test isn't measuring anything in that configuration.
+//! - Persona with `secure_boot.ovmf_variant: ms_enrolled` (or `custom_pk` once that route is in routine use). `disabled` and `setup_mode` Skip — without enforcement, kexec succeeds and the scenario can't measure rejection.
+//! - Persona's `kernel.lockdown` is `integrity` or `confidentiality`. `none` and `inherit` Skip — kexec rejection is lockdown-conditional.
 //!
-//! # When this scenario skips
+//! # When this scenario skips vs fails
 //!
-//! - Stick missing on disk.
-//! - `qemu-system-x86_64` not on PATH.
-//! - `swtpm` missing AND the persona requests TPM.
-//! - Persona's `secure_boot.ovmf_variant` is `disabled` or `setup_mode`.
-//! - Persona's `kernel.lockdown` is `none` (lockdown gates the kexec
-//!   rejection — without it the kernel allows the unsigned load).
+//! - Stick / qemu / swtpm prereqs missing → Skip.
+//! - Persona `ovmf_variant` or `kernel.lockdown` configuration disables the test → Skip.
+//! - Boot didn't reach kernel-userspace handoff (`EFI stub: UEFI Secure Boot is enabled` missing) → Fail (harness pipeline broke).
+//! - Kernel reached but `init: AEGIS_TEST=kexec-unsigned` didn't fire → Skip (cmdline wasn't injected; test isn't measuring anything).
+//! - `init` saw the cmdline but rescue-tui didn't print `kexec-unsigned starting` → Fail (`test_mode` dispatcher regressed).
+//! - Test started but `REJECTED (...)` never appeared → Fail (real bug — kernel UNEXPECTEDLY-LOADED an unsigned blob, OR rescue-tui's diagnostic format drifted).
 
 use crate::persona::{LockdownMode, OvmfVariant};
 use crate::qemu::Invocation;
@@ -51,34 +34,34 @@ use std::time::Duration;
 /// slow under TCG; we match `signed-boot-ubuntu`'s 60s ceiling.
 const LANDMARK_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Pre-test landmarks — boot must reach rescue-tui before we can
-/// trigger or observe the kexec-test. Subset of
-/// `signed_boot_ubuntu::LANDMARKS`; we don't re-assert every step
-/// because that's that scenario's job.
-const PREREQ_LANDMARKS: &[&str] = &[
-    "EFI stub: UEFI Secure Boot is enabled",
-    "rescue-tui starting",
-];
+/// Pre-test landmark — kernel must reach userspace under enforcing SB
+/// before the initramfs can dispatch the test mode. We don't pin
+/// `rescue-tui starting` here because under `aegis.test=...` the
+/// dispatcher fires BEFORE the interactive TUI prints its banner
+/// (see aegis-boot `crates/rescue-tui/src/main.rs` —
+/// `test_mode::dispatch_from_env` returns before `run`).
+const PREREQ_LANDMARKS: &[&str] = &["EFI stub: UEFI Secure Boot is enabled"];
 
-/// The kexec-test landmarks. Expected order:
+/// kexec-test landmarks — published contract from aegis-boot
+/// `docs/rescue-tui-serial-format.md` (see PR #680).
 ///
-/// 1. `aegis-boot-test: kexec-unsigned starting` — rescue-tui's
-///    kexec-test hook fired. Without this we can't tell the test
-///    actually ran (vs. the stick not having the hook compiled in).
-/// 2. `kexec_file_load: failed: -EKEYREJECTED` — kernel rejected
-///    the unsigned kexec. The exact substring is the kernel's
-///    error path printk; format may need adjustment after a real
-///    run captures it. The kernel may emit `-EBADMSG`,
-///    `-ENOPKG`, or `-EKEYREJECTED` depending on the lockdown
-///    pathway hit; the rescue-tui diagnostic below is the
-///    canonical operator-facing assertion.
-/// 3. `aegis-boot-test: kexec-unsigned REJECTED` — rescue-tui's
-///    confirmation that it observed the rejection. Distinct from
-///    the kernel's printk so we don't false-positive on a kernel
-///    line that mentions the errno for an unrelated reason.
+/// 1. `init: AEGIS_TEST=kexec-unsigned` — `/init` saw the cmdline and
+///    exported the env var. Without this, the cmdline didn't propagate
+///    (most likely the operator's stick doesn't carry
+///    `aegis.test=kexec-unsigned` in its grub.cfg) and the test isn't
+///    measuring anything; we Skip.
+/// 2. `aegis-boot-test: kexec-unsigned starting` — rescue-tui's
+///    `dispatch_from_env` fired and entered the test fn. Missing
+///    after step 1 fired = `test_mode` regression.
+/// 3. `aegis-boot-test: kexec-unsigned REJECTED` — substring of all
+///    three legitimate Pass forms (`(errno: EKEYREJECTED)`,
+///    `(errno: EPERM-lockdown)`, `(other: ...)`). The substring
+///    contract from aegis-boot's serial-format doc says
+///    "head string up through the first parenthesis stays identical
+///    across releases" — pinning here is stable.
 const TEST_LANDMARKS: &[&str] = &[
+    "init: AEGIS_TEST=kexec-unsigned",
     "aegis-boot-test: kexec-unsigned starting",
-    "kexec_file_load: failed",
     "aegis-boot-test: kexec-unsigned REJECTED",
 ];
 
@@ -98,67 +81,8 @@ impl Scenario for KexecRefusesUnsigned {
     }
 
     fn run(&self, ctx: &ScenarioContext) -> Result<ScenarioResult, ScenarioError> {
-        // Skip: stick missing.
-        if !ctx.stick.is_file() {
-            return Ok(ScenarioResult::Skip {
-                reason: format!(
-                    "stick {} not found; provision via aegis-boot flash or set AEGIS_HWSIM_STICK",
-                    ctx.stick.display()
-                ),
-            });
-        }
-
-        // Skip: qemu-system-x86_64 missing.
-        if !binary_on_path("qemu-system-x86_64") {
-            return Ok(ScenarioResult::Skip {
-                reason: "qemu-system-x86_64 not on PATH (Debian: apt install qemu-system-x86)"
-                    .to_string(),
-            });
-        }
-
-        // Skip: persona has no Secure Boot enforcement. The whole
-        // point of the test is "kernel + lockdown rejects unsigned
-        // under SB"; if SB is off, the test can't measure anything.
-        match ctx.persona.secure_boot.ovmf_variant {
-            OvmfVariant::Disabled | OvmfVariant::SetupMode => {
-                return Ok(ScenarioResult::Skip {
-                    reason: format!(
-                        "persona {} has ovmf_variant={:?}; kexec-rejection requires \
-                         enforcing Secure Boot (ms_enrolled or custom_pk)",
-                        ctx.persona.id, ctx.persona.secure_boot.ovmf_variant
-                    ),
-                });
-            }
-            OvmfVariant::MsEnrolled | OvmfVariant::CustomPk => {}
-        }
-
-        // Skip: lockdown is `none`. Without lockdown the kernel
-        // allows kexec_file_load of unsigned kernels (under
-        // root/CAP_SYS_BOOT) — the rejection only fires when
-        // lockdown gates it. Inherit-from-firmware also counts as
-        // potentially-disabled for the purposes of this test, so we
-        // require an explicit `integrity` or `confidentiality`.
-        match ctx.persona.kernel.lockdown {
-            LockdownMode::None | LockdownMode::Inherit => {
-                return Ok(ScenarioResult::Skip {
-                    reason: format!(
-                        "persona {} has kernel.lockdown={:?}; kexec-rejection requires \
-                         explicit lockdown=integrity or =confidentiality",
-                        ctx.persona.id, ctx.persona.kernel.lockdown
-                    ),
-                });
-            }
-            LockdownMode::Integrity | LockdownMode::Confidentiality => {}
-        }
-
-        // Skip: swtpm missing AND persona wants TPM.
-        let needs_tpm = !matches!(ctx.persona.tpm.version, crate::persona::TpmVersion::None);
-        if needs_tpm && !binary_on_path("swtpm") {
-            return Ok(ScenarioResult::Skip {
-                reason: "swtpm not on PATH (Debian: apt install swtpm); \
-                         persona requires TPM emulation"
-                    .to_string(),
-            });
+        if let Some(skip) = check_skip_gates(ctx) {
+            return Ok(skip);
         }
 
         // Spawn swtpm (or NoTpm sentinel for personas that opt out).
@@ -176,16 +100,15 @@ impl Scenario for KexecRefusesUnsigned {
         let log_path = ctx.work_dir.join("serial.log");
         let handle = SerialCapture::spawn(inv.build(), &log_path, None)?;
 
-        // First wait for rescue-tui to reach its prompt — same chain
-        // signal `signed-boot-ubuntu` asserts. Without this, the
-        // test landmarks can't fire because rescue-tui's kexec-test
-        // hook hasn't run yet.
+        // First wait for the kernel-userspace handoff under enforcing
+        // SB. Without this, the boot didn't even reach the initramfs
+        // and we have no test surface to measure.
         for landmark in PREREQ_LANDMARKS {
             if handle.wait_for_line(landmark, LANDMARK_TIMEOUT).is_none() {
                 return Ok(ScenarioResult::Fail {
                     reason: format!(
                         "prerequisite landmark '{landmark}' not seen within {}s. \
-                         Boot didn't reach rescue-tui — kexec test can't run. \
+                         Boot didn't reach kernel-userspace handoff — kexec test can't run. \
                          Serial log: {}.",
                         LANDMARK_TIMEOUT.as_secs(),
                         log_path.display(),
@@ -194,19 +117,19 @@ impl Scenario for KexecRefusesUnsigned {
             }
         }
 
-        // Now the test landmarks. The first one ('kexec-unsigned
-        // starting') tells us whether the stick has the test mode
-        // wired in; missing it is a Skip (test wasn't run), not a
-        // Fail (test produced wrong result).
+        // Now the test landmarks. The first one (`init: AEGIS_TEST=...`)
+        // tells us whether the stick's grub.cfg added
+        // `aegis.test=kexec-unsigned` to the cmdline. Missing it = Skip
+        // (test wasn't run), not Fail (test produced wrong result).
         match handle.wait_for_line(TEST_LANDMARKS[0], LANDMARK_TIMEOUT) {
             Some(_) => {}
             None => {
                 return Ok(ScenarioResult::Skip {
                     reason: format!(
-                        "stick reached rescue-tui but did not run kexec-test mode. \
-                         The stick needs an initramfs hook reacting to \
-                         `aegis.test=kexec-unsigned` (kernel cmdline) or an \
-                         operator-typed command. Serial log: {}.",
+                        "kernel reached but `init: AEGIS_TEST=kexec-unsigned` did not fire. \
+                         The stick's grub.cfg needs `aegis.test=kexec-unsigned` on the \
+                         kernel cmdline (see aegis-boot scripts/build-initramfs.sh, PR #680). \
+                         Serial log: {}.",
                         log_path.display()
                     ),
                 });
@@ -214,14 +137,22 @@ impl Scenario for KexecRefusesUnsigned {
         }
 
         // Test mode ran. Remaining landmarks must be observed for Pass.
+        // The REJECTED landmark is the load-bearing assertion — its
+        // absence after `kexec-unsigned starting` fired means either
+        // (a) the kernel UNEXPECTEDLY-LOADED the unsigned blob (real
+        // signed-chain regression — aegis-boot test_mode prints this
+        // explicitly + exits non-zero), or (b) rescue-tui's diagnostic
+        // wording drifted out from under the substring contract.
         for landmark in &TEST_LANDMARKS[1..] {
             if handle.wait_for_line(landmark, LANDMARK_TIMEOUT).is_none() {
                 return Ok(ScenarioResult::Fail {
                     reason: format!(
                         "test landmark '{landmark}' not seen within {}s after \
-                         kexec-test started. Either the kernel didn't reject \
-                         the unsigned kexec (lockdown bypass?) or rescue-tui's \
-                         diagnostic format drifted. Serial log: {}.",
+                         the cmdline-driven test mode entered. Either the kernel \
+                         UNEXPECTEDLY-LOADED an unsigned blob (signed-chain regression) \
+                         or rescue-tui's diagnostic format drifted (see aegis-boot \
+                         docs/rescue-tui-serial-format.md substring contract). \
+                         Serial log: {}.",
                         LANDMARK_TIMEOUT.as_secs(),
                         log_path.display(),
                     ),
@@ -231,6 +162,66 @@ impl Scenario for KexecRefusesUnsigned {
 
         Ok(ScenarioResult::Pass)
     }
+}
+
+/// Skip-gate evaluation extracted from `run()` to keep the runner
+/// under clippy's 100-line ceiling. Returns `Some(Skip)` if any
+/// prerequisite gate fires; `None` if all pass and the runner
+/// should proceed to spawn QEMU.
+fn check_skip_gates(ctx: &ScenarioContext) -> Option<ScenarioResult> {
+    if !ctx.stick.is_file() {
+        return Some(ScenarioResult::Skip {
+            reason: format!(
+                "stick {} not found; provision via aegis-boot flash or set AEGIS_HWSIM_STICK",
+                ctx.stick.display()
+            ),
+        });
+    }
+    if !binary_on_path("qemu-system-x86_64") {
+        return Some(ScenarioResult::Skip {
+            reason: "qemu-system-x86_64 not on PATH (Debian: apt install qemu-system-x86)"
+                .to_string(),
+        });
+    }
+    // Persona must enforce Secure Boot. Disabled / SetupMode short-
+    // circuit because there's no signature gate to fail.
+    match ctx.persona.secure_boot.ovmf_variant {
+        OvmfVariant::Disabled | OvmfVariant::SetupMode => {
+            return Some(ScenarioResult::Skip {
+                reason: format!(
+                    "persona {} has ovmf_variant={:?}; kexec-rejection requires \
+                     enforcing Secure Boot (ms_enrolled or custom_pk)",
+                    ctx.persona.id, ctx.persona.secure_boot.ovmf_variant
+                ),
+            });
+        }
+        OvmfVariant::MsEnrolled | OvmfVariant::CustomPk => {}
+    }
+    // Without lockdown the kernel allows `kexec_file_load` of unsigned
+    // kernels (under root/CAP_SYS_BOOT). Inherit-from-firmware also
+    // counts as potentially-disabled; require an explicit
+    // `integrity` or `confidentiality`.
+    match ctx.persona.kernel.lockdown {
+        LockdownMode::None | LockdownMode::Inherit => {
+            return Some(ScenarioResult::Skip {
+                reason: format!(
+                    "persona {} has kernel.lockdown={:?}; kexec-rejection requires \
+                     explicit lockdown=integrity or =confidentiality",
+                    ctx.persona.id, ctx.persona.kernel.lockdown
+                ),
+            });
+        }
+        LockdownMode::Integrity | LockdownMode::Confidentiality => {}
+    }
+    let needs_tpm = !matches!(ctx.persona.tpm.version, crate::persona::TpmVersion::None);
+    if needs_tpm && !binary_on_path("swtpm") {
+        return Some(ScenarioResult::Skip {
+            reason: "swtpm not on PATH (Debian: apt install swtpm); \
+                     persona requires TPM emulation"
+                .to_string(),
+        });
+    }
+    None
 }
 
 #[cfg(test)]

--- a/src/scenarios/mok_enroll_alpine.rs
+++ b/src/scenarios/mok_enroll_alpine.rs
@@ -1,26 +1,25 @@
-//! `mok-enroll-alpine` — boot Alpine (unsigned kernel) under MS-enrolled Secure Boot, assert aegis-boot's rescue-tui surfaces the MOK enrollment walkthrough STEP 1/3 (`sudo mokutil --import`).
+//! `mok-enroll-alpine` — boot under MS-enrolled SB with `aegis.test=mok-enroll` on the kernel cmdline, assert aegis-boot's rescue-tui surfaces the MOK enrollment walkthrough STEP 1/3 (`sudo mokutil --import`) verbatim per [aegis-boot#202](https://github.com/aegis-boot/aegis-boot/pull/202) and [PR #681](https://github.com/aegis-boot/aegis-boot/pull/681).
 //!
 //! # What this scenario asserts
 //!
-//! 1. Persona boots successfully (shim → grub → kernel rejected → fallback path → rescue-tui), same prerequisite chain as [`super::SignedBootUbuntu`].
-//! 2. Rescue-tui detects an unsigned/unrecognized kernel was attempted and surfaces the MOK enrollment walkthrough — the operator-facing recovery path documented in aegis-boot#202.
-//! 3. The walkthrough's STEP 1 surfaces the `sudo mokutil --import` command verbatim. Operators will literally copy-paste it; the harness asserts the exact string so a future drift in #202's docstring lights up here rather than confusing an operator at 2am.
+//! 1. Persona boots successfully (shim → grub → kernel → init), same prerequisite chain as [`super::SignedBootUbuntu`].
+//! 2. The initramfs detects `aegis.test=mok-enroll` on the kernel cmdline and exports `AEGIS_TEST=mok-enroll`. `init` prints `init: AEGIS_TEST=mok-enroll (cmdline-driven test mode)` per [aegis-boot `scripts/build-initramfs.sh`](https://github.com/aegis-boot/aegis-boot/pull/680).
+//! 3. Rescue-tui's `dispatch_from_env` fires the `mok-enroll` test mode, which prints the canonical 3-step walkthrough body — same text the rescue-tui kexec-failure path renders, sourced from aegis-boot's `crate::state::build_mokutil_remedy`. This is a static-text mode (no kexec, no ISO) so the harness asserts the contract without driving a real unsigned-kernel boot.
+//! 4. The walkthrough's STEP 1 surfaces the `sudo mokutil --import` command verbatim. Operators will literally copy-paste it; the harness asserts the exact string so a future drift in #202's text lights up here rather than confusing an operator at 2 AM.
 //!
 //! # Prerequisites
 //!
-//! - An aegis-boot stick with an Alpine ISO loaded (or an Alpine boot path the rescue-tui surfaces). The stick fixture path is supplied via [`ScenarioContext::stick`]; the operator stages it via `aegis-boot flash` or the `AEGIS_HWSIM_STICK` env var (matching the convention from `signed_boot_ubuntu`).
-//! - Persona with `secure_boot.ovmf_variant: ms_enrolled`. `custom_pk` would also work but the MOK enrollment story is specifically about the MS-enrolled / vendor-shim path; `disabled` and `setup_mode` short-circuit because there's no signature gate to fail.
+//! - An aegis-boot stick whose grub.cfg adds `aegis.test=mok-enroll` to the kernel cmdline (same shape as [`super::KexecRefusesUnsigned`]). A stick that boots cleanly without the cmdline will Skip.
+//! - Persona with `secure_boot.ovmf_variant: ms_enrolled`. `custom_pk` (operator owns root keys, mokutil's job is gone), `disabled` (no signature gate), and `setup_mode` (no PK enrolled) all Skip.
 //!
-//! # When this scenario skips
+//! # When this scenario skips vs fails
 //!
-//! - Stick missing on disk.
-//! - `qemu-system-x86_64` not on PATH.
-//! - `swtpm` missing AND the persona requests TPM.
-//! - Persona's `secure_boot.ovmf_variant` isn't `ms_enrolled`.
-//!
-//! # When this scenario fails (vs skips)
-//!
-//! Boot didn't reach rescue-tui's prereq landmarks → `Fail` (the harness pipeline broke). Boot reached rescue-tui but the MOK walkthrough never fired → `Skip` (the stick wasn't built with the unsigned-Alpine path). Walkthrough fired but the literal `sudo mokutil --import` command didn't appear → `Fail` (real bug — aegis-boot#202's text drifted, an operator running this would be stuck).
+//! - Stick / qemu / swtpm prereqs missing → Skip.
+//! - Persona `ovmf_variant` isn't `ms_enrolled` → Skip.
+//! - Boot didn't reach kernel-userspace handoff → Fail (harness pipeline broke).
+//! - Kernel reached but `init: AEGIS_TEST=mok-enroll` didn't fire → Skip (cmdline wasn't injected).
+//! - `init` saw the cmdline but rescue-tui didn't print the walkthrough header → Fail (`test_mode` dispatcher regressed).
+//! - Walkthrough header fired but STEP 1/3 + the literal `sudo mokutil --import` command didn't appear → Fail (real bug — aegis-boot#202's text drifted; operators in the field would be stuck).
 
 use crate::persona::OvmfVariant;
 use crate::qemu::Invocation;
@@ -33,20 +32,32 @@ use std::time::Duration;
 /// Per-landmark wait timeout. Same 60s ceiling as the other scenarios — cold-boot OVMF + MS-enrolled SB chain + rescue-tui walkthrough is the slow path.
 const LANDMARK_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Pre-walkthrough landmarks: the chain has to reach rescue-tui before the walkthrough can fire.
-const PREREQ_LANDMARKS: &[&str] = &[
-    "EFI stub: UEFI Secure Boot is enabled",
-    "rescue-tui starting",
-];
+/// Pre-test landmark — kernel must reach userspace before the
+/// initramfs can dispatch the test mode. We don't pin
+/// `rescue-tui starting` here because under `aegis.test=...` the
+/// dispatcher fires BEFORE the interactive TUI prints its banner
+/// (see aegis-boot `crates/rescue-tui/src/main.rs` —
+/// `test_mode::dispatch_from_env` returns before `run`).
+const PREREQ_LANDMARKS: &[&str] = &["EFI stub: UEFI Secure Boot is enabled"];
 
-/// MOK enrollment walkthrough landmarks. Order is significant — STEP 1 must come before STEP 2/3.
+/// MOK walkthrough landmarks — published contract from aegis-boot
+/// `docs/rescue-tui-serial-format.md` (see PR #681). Order is
+/// significant: cmdline detection → walkthrough header → step
+/// marker → load-bearing copy-paste command.
 ///
-/// 1. `MOK enrollment walkthrough` — rescue-tui's section header. Without this we can't tell whether the walkthrough actually ran (vs. the stick not having the Alpine/MOK hook compiled in).
-///
-/// 2. `STEP 1/3` — section marker for the `mokutil --import` step. aegis-boot#202 ships exactly three steps; the harness asserts step 1 because that's the load-bearing one (without it the operator can't proceed).
-///
-/// 3. `sudo mokutil --import` — the literal copy-paste command. This is the assertion the issue body specifically calls out: "assert the MOK walkthrough STEP 1/3 `sudo mokutil --import` command string appears in the serial log exactly as #202 ships it". A future drift in #202 lights up here.
+/// 1. `init: AEGIS_TEST=mok-enroll` — `/init` saw the cmdline. Missing
+///    this means the stick's grub.cfg didn't inject the param;
+///    test isn't measuring anything → Skip.
+/// 2. `MOK enrollment walkthrough` — rescue-tui's `mok-enroll` test
+///    fn fired. Substring matches both the `starting` header and
+///    the `complete` footer.
+/// 3. `STEP 1/3` — section marker for the `mokutil --import` step.
+///    Confirms the walkthrough body printed.
+/// 4. `sudo mokutil --import` — the verbatim copy-paste payload.
+///    Drift here would leave an operator at 2 AM with a non-working
+///    command line — the harness exists to catch exactly this.
 const TEST_LANDMARKS: &[&str] = &[
+    "init: AEGIS_TEST=mok-enroll",
     "MOK enrollment walkthrough",
     "STEP 1/3",
     "sudo mokutil --import",
@@ -128,14 +139,14 @@ impl Scenario for MokEnrollAlpine {
         let log_path = ctx.work_dir.join("serial.log");
         let handle = SerialCapture::spawn(inv.build(), &log_path, None)?;
 
-        // Wait for rescue-tui to come up first. Without this the
-        // walkthrough landmarks can never fire.
+        // First wait for the kernel-userspace handoff under enforcing
+        // SB. Without this, the boot didn't even reach the initramfs.
         for landmark in PREREQ_LANDMARKS {
             if handle.wait_for_line(landmark, LANDMARK_TIMEOUT).is_none() {
                 return Ok(ScenarioResult::Fail {
                     reason: format!(
                         "prerequisite landmark '{landmark}' not seen within {}s. \
-                         Boot didn't reach rescue-tui — MOK walkthrough can't fire. \
+                         Boot didn't reach kernel-userspace handoff — MOK walkthrough can't fire. \
                          Serial log: {}.",
                         LANDMARK_TIMEOUT.as_secs(),
                         log_path.display(),
@@ -144,35 +155,40 @@ impl Scenario for MokEnrollAlpine {
             }
         }
 
-        // First walkthrough landmark — its absence means the stick
-        // didn't actually trigger the MOK path. Skip (test wasn't
-        // run), don't Fail.
+        // First test landmark — `/init` cmdline detection. Missing it
+        // means the stick's grub.cfg didn't inject `aegis.test=mok-enroll`;
+        // test isn't measuring anything → Skip (not Fail).
         match handle.wait_for_line(TEST_LANDMARKS[0], LANDMARK_TIMEOUT) {
             Some(_) => {}
             None => {
                 return Ok(ScenarioResult::Skip {
                     reason: format!(
-                        "stick reached rescue-tui but the MOK enrollment walkthrough \
-                         didn't fire. The stick needs an Alpine ISO entry that grub \
-                         attempts under SB, OR an `aegis.test=mok-enroll` cmdline \
-                         hook. Serial log: {}.",
+                        "kernel reached but `init: AEGIS_TEST=mok-enroll` did not fire. \
+                         The stick's grub.cfg needs `aegis.test=mok-enroll` on the \
+                         kernel cmdline (see aegis-boot scripts/build-initramfs.sh, PR #680). \
+                         Serial log: {}.",
                         log_path.display()
                     ),
                 });
             }
         }
 
-        // Walkthrough fired. Remaining landmarks (STEP 1/3 + the
-        // exact mokutil command) MUST appear, otherwise aegis-boot#202
-        // drifted and operators would be left without a copy-pastable
-        // command — that's a real defect, not a Skip.
+        // Test mode entered. Remaining landmarks (walkthrough header,
+        // STEP 1/3, mokutil command) MUST appear, otherwise either
+        // (a) the rescue-tui dispatcher regressed (init saw the
+        // cmdline but rescue-tui didn't fire the walkthrough), or
+        // (b) aegis-boot#202's text drifted and operators in the
+        // field would be stuck without a copy-pastable command.
+        // Both are real defects, not Skip conditions.
         for landmark in &TEST_LANDMARKS[1..] {
             if handle.wait_for_line(landmark, LANDMARK_TIMEOUT).is_none() {
                 return Ok(ScenarioResult::Fail {
                     reason: format!(
-                        "walkthrough started but '{landmark}' not seen within {}s. \
-                         aegis-boot#202's MOK walkthrough drifted; an operator \
-                         hitting this in the field would be stuck. Serial log: {}.",
+                        "init detected the cmdline but '{landmark}' not seen within {}s. \
+                         Either rescue-tui's mok-enroll dispatcher regressed, or \
+                         aegis-boot#202's MOK walkthrough text drifted (see \
+                         docs/rescue-tui-serial-format.md substring contract). \
+                         Serial log: {}.",
                         LANDMARK_TIMEOUT.as_secs(),
                         log_path.display(),
                     ),


### PR DESCRIPTION
## Summary

aegis-boot just shipped its half of the E5 cross-repo coordination:

- [aegis-boot#680](https://github.com/aegis-boot/aegis-boot/pull/680) — `feat(rescue-tui)`: kexec-unsigned test mode + serial format docs (closes the issue we filed)
- [aegis-boot#681](https://github.com/aegis-boot/aegis-boot/pull/681) — `feat(rescue-tui)`: mok-enroll test mode (companion)

Published contract:
- `docs/rescue-tui-serial-format.md` — substring stability policy + per-mode landmark tables
- `scripts/build-initramfs.sh` — cmdline → `AEGIS_TEST` env propagation
- `crates/rescue-tui/src/test_mode.rs` — dispatcher + landmark emitter

This PR tightens aegis-hwsim's `TEST_LANDMARKS` to match the published substrings exactly.

## Three changes per scenario

### 1. Drop `rescue-tui starting` from `PREREQ_LANDMARKS`

The test-mode dispatcher fires **before** the interactive TUI prints its banner — see aegis-boot `crates/rescue-tui/src/main.rs`: `test_mode::dispatch_from_env` returns before `run`. Asserting on `rescue-tui starting` would be a guaranteed Skip-vs-Pass regression once the cmdline is wired in.

### 2. Add `init: AEGIS_TEST=<name>` as the first TEST_LANDMARK

`/init`'s cmdline detection prints this *before* handing to rescue-tui. Missing it = stick's `grub.cfg` didn't inject `aegis.test=<name>` → **Skip**. Present but rescue-tui landmarks missing = real `test_mode` regression → **Fail**. The new sequence keeps the existing Skip/Fail split semantics correct.

### 3. Drop the speculative `kexec_file_load: failed` middle landmark

(kexec_refuses_unsigned only) — the kernel's printk doesn't necessarily emit that. The rescue-tui's `REJECTED` landmark covers all three legitimate Pass forms (`EKEYREJECTED`, `EPERM-lockdown`, `other:`) per the substring stability policy in `docs/rescue-tui-serial-format.md`:

> additional tokens may be appended (e.g. wrap a numeric errno value), but the head string up through the first parenthesis stays identical across releases.

## Drive-bys

- Extracted `check_skip_gates()` helper from `kexec_refuses_unsigned::run` to fit clippy's 100-line ceiling after the longer error messages.
- Module docstrings now point at aegis-boot PR #680/#681 + link the cross-repo serial-format contract doc.
- Skip/Fail messages now point operators at aegis-boot's `build-initramfs.sh` + the substring contract — actionable next step instead of a generic "stick wasn't built right".

## Test plan

- [x] `cargo +1.85.0 fmt --check` clean
- [x] `cargo +1.85.0 clippy --all-targets -- -D warnings` clean (including the `too_many_lines` lint that the longer error messages tripped)
- [x] `cargo +1.85.0 test --lib` — 122 tests pass; same skip-gate coverage on the kexec scenario via the extracted helper
- [x] `cargo run -- list-scenarios` still shows 4 scenarios with updated descriptions
- [x] `cargo run -- gen-schema --check` clean
- [ ] CI green

Refs aegis-hwsim#5 (closes the harness side of E5.3+E5.4 against the now-shipped aegis-boot test modes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)