### PR TITLE
ci: SHA-pin all GitHub Actions (supply-chain hygiene pre-v0.1.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     # variants), the CLAUDE.md non-negotiable max-parallel: 4 lives
     # here — `strategy: { matrix: ..., max-parallel: 4 }`.
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install Rust
         run: |
           rustup toolchain install 1.85.0 --profile minimal --component clippy,rustfmt
@@ -69,7 +69,7 @@ jobs:
           cargo run --locked -q --bin aegis-hwsim -- coverage-grid > artifacts/coverage-grid.md
           cargo run --locked -q --bin aegis-hwsim -- coverage-grid --format json > artifacts/coverage-grid.json
       - name: Upload coverage-grid artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: coverage-grid
           path: artifacts/coverage-grid.*

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install Rust toolchain (pinned to MSRV)
         # CodeQL needs cargo+rustc available to autobuild. Pin to the
@@ -69,7 +69,7 @@ jobs:
           rustup default 1.85.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
         with:
           languages: ${{ matrix.language }}
           # security-extended is the full CodeQL query suite; the
@@ -78,9 +78,9 @@ jobs:
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
 
       - name: Perform analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -46,7 +46,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install Rust toolchain (pinned)
         run: |
@@ -71,7 +71,7 @@ jobs:
         run: ./scripts/audit-no-test-keys.sh
 
       - name: Mint short-lived crates.io token (OIDC)
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: cio_auth
 
       - name: publish aegis-hwsim


### PR DESCRIPTION
## Summary

Eight action references were on floating major-version tags. Mutable tags can be re-pointed by the action's maintainer to a different commit without notice — a real supply-chain hijack vector for any project that lands secrets on tag push (we land an OIDC crates.io token via `rust-lang/crates-io-auth-action`).

Per the consensus vote on the v0.1.0 prep round (security engineer flagged this as critical pre-release supply-chain control), all action references are now pinned to commit SHAs.

## Pinning convention

Format: `<owner>/<repo>@<SHA-40> # v<TAG>`. The trailing comment lets:

1. The current version be grep-able by humans
2. Dependabot/Renovate update PRs change both fields in lockstep
3. A maintainer find the next SHA via `gh api repos/<owner>/<repo>/git/refs/tags/<v>`

## Locked refs

| File | Ref | SHA | Tag |
|---|---|---|---|
| ci.yml | actions/checkout | `93cb6ef…` | v5 |
| ci.yml | actions/upload-artifact | `330a01c…` | v5 |
| codeql.yml | actions/checkout | `93cb6ef…` | v5 |
| codeql.yml | github/codeql-action/init | `865f5f5…` | v3 |
| codeql.yml | github/codeql-action/autobuild | `865f5f5…` | v3 |
| codeql.yml | github/codeql-action/analyze | `865f5f5…` | v3 |
| crates-publish.yml | actions/checkout | `93cb6ef…` | v5 |
| crates-publish.yml | rust-lang/crates-io-auth-action | `bbd8162…` | v1.0.4 |

## Test plan

- [x] `python3 -c "import yaml; ..."` — all three workflow files parse cleanly
- [x] `grep "uses: " .github/workflows/*.yml` shows every `uses:` line carries a 40-char SHA
- [ ] CI green (no behavior change for green runs)

Refs #7 (E7 v1.0 release gate hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)