### PR TITLE
fix(publish): handle [package] in addition to [workspace.package]

### DIFF
--- a/scripts/publish-if-new.sh
+++ b/scripts/publish-if-new.sh
@@ -38,27 +38,39 @@ if [[ -z "$CRATE" ]]; then
     exit 2
 fi
 
-# Workspace version: prefer explicit env (CI sets this) so we don't
-# have to re-parse Cargo.toml inside a runner where awk + grep can
-# get tripped by inline comments.
+# Crate version: prefer explicit env (CI can set it) so we don't have
+# to re-parse Cargo.toml inside a runner where awk + grep can get
+# tripped by inline comments.
+#
+# This script started life mirroring aegis-boot's wrapper, which is a
+# workspace and exposes its version via `[workspace.package].version`.
+# aegis-hwsim is a single-crate project with `[package].version`.
+# Walk both sections so the script works on either shape — the first
+# version it finds wins, with `[package]` checked first because that's
+# the single-crate idiom.
 if [[ -z "${WORKSPACE_VERSION:-}" ]]; then
     SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
     REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-    WORKSPACE_VERSION="$(
-        awk '
-            /^\[workspace\.package\]/ { f=1; next }
-            f && /^\[/                 { exit }
-            f && /^version = /         {
-                gsub(/^version = "|"$/, "", $0)
-                print
-                exit
-            }
-        ' "$REPO_ROOT/Cargo.toml"
-    )"
+    for SECTION in "package" "workspace.package"; do
+        WORKSPACE_VERSION="$(
+            awk -v section="[${SECTION}]" '
+                $0 == section            { f=1; next }
+                f && /^\[/               { exit }
+                f && /^version = /       {
+                    gsub(/^version = "|"$/, "", $0)
+                    print
+                    exit
+                }
+            ' "$REPO_ROOT/Cargo.toml"
+        )"
+        [[ -n "$WORKSPACE_VERSION" ]] && break
+    done
 fi
 
 if [[ -z "$WORKSPACE_VERSION" ]]; then
-    echo "publish-if-new: ERROR — could not parse workspace version" >&2
+    echo "publish-if-new: ERROR — could not parse crate version from Cargo.toml" >&2
+    echo "publish-if-new:   tried [package] and [workspace.package] sections" >&2
+    echo "publish-if-new:   set WORKSPACE_VERSION env var to override" >&2
     exit 2
 fi
 


### PR DESCRIPTION
## Why this PR

The v0.1.0 publish failed at `publish-if-new.sh`:

\`\`\`
publish-if-new: ERROR — could not parse workspace version
\`\`\`

Run: https://github.com/aegis-boot/aegis-hwsim/actions/runs/25142121486

## Root cause

The wrapper was cribbed from aegis-boot's publish flow, which is a workspace and exposes its version via `[workspace.package].version`. **aegis-hwsim is a single-crate project** with `[package].version` — the awk pattern `/^\[workspace\.package\]/` never matched, so `WORKSPACE_VERSION` came back empty.

## Fix

Walk both sections, `[package]` first because that's the single-crate idiom. First version found wins. Error message updated to point operators at the `WORKSPACE_VERSION` env-var override.

## Local verification

\`\`\`
$ WORKSPACE_VERSION="" ./scripts/publish-if-new.sh aegis-hwsim
publish-if-new: aegis-hwsim — workspace=0.1.0, live=<not on registry>
publish-if-new: publishing aegis-hwsim v0.1.0...
\`\`\`

(Local `cargo publish` then fails for lack of a registry token, which is the correct behavior for non-CI invocations.)

## After merge

Two paths to actually ship 0.1.0:

1. Force-retag `v0.1.0` (delete + recreate pointing at the new merge commit) → re-trigger `crates-publish.yml`. Clean for a release that hasn't actually published anywhere yet.
2. Tag `v0.1.1` instead. The wrapper is idempotent and would skip if v0.1.0 had published, but since nothing's on crates.io yet, this version-bumps unnecessarily.

I'll go with option 1 — retag v0.1.0 — since it preserves the version-1.0-was-1.0 narrative and nothing actually published.

## Test plan

- [x] `bash -n scripts/publish-if-new.sh` clean
- [x] Local invocation against aegis-hwsim's Cargo.toml correctly extracts `0.1.0`
- [ ] CI green (this PR's CI doesn't exercise the script — the script runs only on tag push)

Refs #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)