### PR TITLE
release: v0.1.1 — --personas-dir + --firmware-root global flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to aegis-hwsim. Mirrors the [Keep a Changelog](https://keepa
 
 ## [Unreleased]
 
+## [0.1.1] — 2026-04-30
+
+UX patch for cargo-installed users.
+
+### Fixed
+
+- **`cargo install aegis-hwsim` now works from any cwd.** v0.1.0 surfaced a UX papercut: the binary always resolved `personas/` relative to cwd, so a `cargo install`-ed binary outside a checkout failed with `read "/some/cwd/personas": No such file or directory`. v0.1.1 adds a `--personas-dir DIR` global flag (and matching `--firmware-root DIR`) accepted by every persona-loading subcommand. Default behavior unchanged for in-repo runs. Help text updated to call out the cargo-installed flow + point at the github repo for fetching persona fixtures.
+
 ## [0.1.0] — 2026-04-30
 
 First crates.io publish. Closes E5 (MOK + unsigned-kexec) and E6 (attestation roundtrip) structurally; partially closes E7 (v1.0 release gate — the trusted-publishing pipeline now publishes a real release). Five scenarios shipped, ~150 tests, CodeQL clean, full release-readiness gate (audit + `cargo publish --dry-run`) on every CI run.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aegis-hwsim"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aegis-hwsim"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ See [aegis-boot#51](https://github.com/williamzujkowski/aegis-boot/issues/51), [
 
 ## Quick start
 
+### From crates.io
+
+```bash
+cargo install aegis-hwsim                         # Installs the orchestrator binary
+
+# Persona fixtures + firmware/test-keyring don't ship in the cargo
+# package by design. Clone the repo for the YAML library and pass
+# its paths via the global flags:
+git clone https://github.com/williamzujkowski/aegis-hwsim /tmp/aegis-hwsim
+
+# Smoke-test the install
+aegis-hwsim --version --json
+aegis-hwsim list-personas \
+    --personas-dir /tmp/aegis-hwsim/personas \
+    --firmware-root /tmp/aegis-hwsim/firmware
+```
+
+`--personas-dir` and `--firmware-root` are accepted by every persona-loading subcommand. Default behavior (no flags) resolves both relative to cwd — that's the in-repo developer flow below.
+
+### From a checkout (the harness's own dev flow)
+
 ```bash
 git clone https://github.com/williamzujkowski/aegis-hwsim
 cd aegis-hwsim

--- a/src/bin/aegis-hwsim.rs
+++ b/src/bin/aegis-hwsim.rs
@@ -102,16 +102,37 @@ fn print_help() {
     println!("  aegis-hwsim --version               Print version");
     println!("  aegis-hwsim --help                  This message");
     println!();
-    println!("All paths resolve against the current working directory. Run from the");
-    println!("repo root (or the directory containing personas/ and firmware/).");
+    println!("GLOBAL FLAGS (accepted by every persona-loading subcommand):");
+    println!("  --personas-dir DIR    Override the persona library path");
+    println!("                        (default: ./personas relative to cwd)");
+    println!("  --firmware-root DIR   Override the firmware root used for");
+    println!("                        custom_keyring resolution");
+    println!("                        (default: ./firmware relative to cwd)");
+    println!();
+    println!("`cargo install`-ed users: pass `--personas-dir <repo>/personas`");
+    println!("(clone https://github.com/williamzujkowski/aegis-hwsim) since the");
+    println!("crates.io binary doesn't ship persona fixtures by design.");
 }
 
-/// Shared helper — resolves the cwd-relative `LoadOptions` and calls into
-/// the loader. Returns the personas on success or prints the error to
-/// stderr and returns the appropriate `ExitCode`.
-fn load_or_report() -> Result<Vec<Persona>, ExitCode> {
+/// Shared helper — resolves the cwd-relative `LoadOptions`, applies any
+/// `--personas-dir` / `--firmware-root` overrides from `args`, and
+/// calls into the loader. Returns the personas on success or prints
+/// the error to stderr and returns the appropriate `ExitCode`.
+///
+/// Without overrides this matches the original behavior: `personas/`
+/// and `firmware/` resolved against cwd (so a developer running from
+/// the repo root just works). With `--personas-dir <DIR>` the binary
+/// becomes useful from any cwd — important now that v0.1.0 ships
+/// via `cargo install`, where the operator's cwd is not the repo.
+fn load_or_report(args: &[String]) -> Result<Vec<Persona>, ExitCode> {
     let cwd = cwd_or_exit()?;
-    let opts = LoadOptions::default_at(&cwd);
+    let mut opts = LoadOptions::default_at(&cwd);
+    if let Some(p) = flag_value(args, "--personas-dir") {
+        opts.personas_dir = PathBuf::from(p);
+    }
+    if let Some(p) = flag_value(args, "--firmware-root") {
+        opts.firmware_root = PathBuf::from(p);
+    }
     match load_all(&opts) {
         Ok(personas) => Ok(personas),
         Err(e) => {
@@ -134,7 +155,7 @@ fn run_validate(args: &[String]) -> ExitCode {
         return ExitCode::SUCCESS;
     }
     let quiet = args.iter().any(|a| a == "--quiet");
-    match load_or_report() {
+    match load_or_report(args) {
         Ok(personas) => {
             if !quiet {
                 for p in &personas {
@@ -163,7 +184,7 @@ fn run_list(args: &[String]) -> ExitCode {
         return ExitCode::SUCCESS;
     }
     let json_mode = args.iter().any(|a| a == "--json");
-    match load_or_report() {
+    match load_or_report(args) {
         Ok(personas) => {
             if json_mode {
                 print_list_json(&personas);
@@ -386,7 +407,7 @@ fn run_coverage_grid(args: &[String]) -> ExitCode {
 
     let firmware_root = flag_path_or(args, "--firmware-root", "/usr/share/OVMF");
 
-    let personas = match load_or_report() {
+    let personas = match load_or_report(args) {
         Ok(p) => p,
         Err(code) => return code,
     };
@@ -562,7 +583,7 @@ fn run_scenario(args: &[String]) -> ExitCode {
         work_dir,
     } = parsed;
 
-    let personas = match load_or_report() {
+    let personas = match load_or_report(args) {
         Ok(p) => p,
         Err(code) => return code,
     };


### PR DESCRIPTION
## Why this PR

Smoke-tested v0.1.0 from crates.io and surfaced a UX papercut:

\`\`\`
$ cargo install aegis-hwsim
$ cd /tmp && aegis-hwsim list-personas
aegis-hwsim: read "/tmp/personas": No such file or directory (exit 1)
\`\`\`

The orchestrator always resolved \`personas/\` relative to cwd, so a cargo-installed binary outside a checkout always failed. v0.1.0 documentation mentioned this implicitly ("run from the repo root") but that's brittle UX for someone who just \`cargo install\`-ed.

## What this ships

Two global flags accepted by every persona-loading subcommand:

| Flag | Default | Effect |
|---|---|---|
| `--personas-dir DIR` | `./personas` | Override the persona library path |
| `--firmware-root DIR` | `./firmware` | Override the firmware root for `custom_keyring` resolution |

In-repo developer flow unchanged. Out-of-repo flow now works:

\`\`\`bash
aegis-hwsim list-personas \
    --personas-dir /path/to/aegis-hwsim/personas \
    --firmware-root /path/to/aegis-hwsim/firmware
\`\`\`

Help text updated with a `GLOBAL FLAGS` section pointing `cargo install` users at the github repo for fetching fixtures. README quick-start grows a `From crates.io` block showing the new flow.

## Test plan

- [x] `cargo +1.85.0 fmt --check` clean
- [x] `cargo +1.85.0 clippy --all-targets -- -D warnings` clean
- [x] `cargo +1.85.0 test --lib` — 128 tests pass (no test changes)
- [x] `cargo +1.85.0 publish --dry-run --allow-dirty` packages `aegis-hwsim v0.1.1` cleanly
- [x] Smoke: from `/tmp`, `aegis-hwsim list-personas --personas-dir … --firmware-root …` lists 11 personas
- [ ] CI green
- [ ] After merge: retag as `v0.1.1` → `crates-publish.yml` fires → second crates.io release

🤖 Generated with [Claude Code](https://claude.com/claude-code)